### PR TITLE
Fix function name manageContractSelects

### DIFF
--- a/Public/js/crm.js
+++ b/Public/js/crm.js
@@ -50,7 +50,7 @@ $(document).ready(function() {
             attr('href', `${ameise_base_url}maklerportal/?show=kunde&kunde=${selectedObject.id}`);
             archive_btn.show();
             $("#contract-tag-dropdown, #division-tag-dropdown").show();
-            mangeContractSelects();
+            manageContractSelects();
         });
     });
 
@@ -171,7 +171,7 @@ $(document).ready(function() {
         });
     });
 
-    function mangeContractSelects() {
+    function manageContractSelects() {
         $('#contract-tag-dropdown, #division-tag-dropdown').select2({
             placeholder: 'Select options',
             width: '350px',


### PR DESCRIPTION
## Summary
- fix typo `mangeContractSelects` -> `manageContractSelects`
- update call to new function name

## Testing
- `grep -nR manageContractSelects -n`


------
https://chatgpt.com/codex/tasks/task_e_684006376f9483278b6110616b41dad8