### PR TITLE
Fix session auto refresh

### DIFF
--- a/Http/Controllers/AmeiseController.php
+++ b/Http/Controllers/AmeiseController.php
@@ -30,6 +30,13 @@ class AmeiseController extends Controller
         });
 
     }
+
+    public function refreshToken()
+    {
+        $this->tokenService = $this->tokenService ?? new TokenService('', auth()->user()->id);
+        $this->tokenService->getAccessToken();
+        return response()->json(['status' => 'ok']);
+    }
     /**
      *  @return Response Crm ajax controller.
      */

--- a/Http/routes.php
+++ b/Http/routes.php
@@ -5,6 +5,7 @@ Route::group(['middleware' => 'web', 'prefix' => \Helper::getSubdirectory(), 'na
     Route::get('/', 'AmeiseModuleController@index');
     Route::get('/ameise/{id}/get-contracts', ['uses' => 'AmeiseController@getContracts'])->name('ameise.get.contracts');
     Route::post('/ameise/ajax', ['uses' => 'AmeiseController@ajax', 'laroute' => true])->name('ameise.ajax');
+    Route::get('/ameise/refresh-token', ['uses' => 'AmeiseController@refreshToken'])->name('ameise.refresh');
     Route::get('/crm/auth', ['uses' => 'AmeiseModuleController@auth', 'laroute' => true])->name('crm.auth');
 
 });

--- a/Resources/views/partials/conversation_button.blade.php
+++ b/Resources/views/partials/conversation_button.blade.php
@@ -16,4 +16,9 @@
         type="text/css">
     <script src="{{ Module::getPublicPath(AMEISE_MODULE) . '/js/awesomplete.js' }}"  {!! \Helper::cspNonceAttr() !!}></script>
     <script src="{{ Module::getPublicPath(AMEISE_MODULE) . '/js/crm.js' }}"  {!! \Helper::cspNonceAttr() !!}></script>
+    <script {!! \Helper::cspNonceAttr() !!}>
+        setInterval(function () {
+            fetch('/ameise/refresh-token');
+        }, 3300000);
+    </script>
 @endsection


### PR DESCRIPTION
## Summary
- allow TokenService refresh without auth code
- store real expiry timestamp
- return result when refreshing token
- add `/ameise/refresh-token` endpoint and JS auto-refresh

## Testing
- `composer validate --no-check-all --strict`
- `php -l Services/TokenService.php`
- `php -l Http/Controllers/AmeiseController.php`
- `php -l Http/routes.php`
- `php -l Resources/views/partials/conversation_button.blade.php`


------
https://chatgpt.com/codex/tasks/task_e_6840b5e99c4483279ef56de1d7236b42