### PR TITLE
Replace maklerinfo domain with ameise.app in portal links

### DIFF
--- a/Resources/views/partials/contracts.blade.php
+++ b/Resources/views/partials/contracts.blade.php
@@ -41,7 +41,7 @@
 
                             <div class="conversation-archives">
                                 <a style="font-size:14px;" target="_blank"
-                                   href="{{ (config('ameisemodule.ameise_mode') == 'test' ? 'https://maklerinfo.inte.dionera.dev' : 'https://www.maklerinfo.biz') }}/maklerportal/?show=kunde&kunde={{ $user['id'] ?? '' }}">
+                                   href="{{ (config('ameisemodule.ameise_mode') == 'test' ? 'https://maklerinfo.inte.dionera.dev' : 'https://ameise.app') }}/maklerportal/?show=kunde&kunde={{ $user['id'] ?? '' }}">
                                     <p>{{ $user['text'] ?? '' }}</p>
                                 </a>
 

--- a/Resources/views/partials/conversation_button.blade.php
+++ b/Resources/views/partials/conversation_button.blade.php
@@ -9,7 +9,7 @@
     src="{{ Module::getPublicPath(AMEISE_MODULE) . '/images/ameise_icon_bold_red.svg' }}"></a>
 @endif
 <link href="{{ asset(Module::getPublicPath(AMEISE_MODULE) . '/css/style.css') }}" rel="stylesheet" type="text/css">
-<input type="hidden" id="ameise_base_url" value="{{ (config('ameisemodule.ameise_mode') == 'test' ? 'https://maklerinfo.inte.dionera.dev/' : 'https://www.maklerinfo.biz/') }}">
+<input type="hidden" id="ameise_base_url" value="{{ (config('ameisemodule.ameise_mode') == 'test' ? 'https://maklerinfo.inte.dionera.dev/' : 'https://ameise.app/') }}">
 @section('javascripts')
     @parent
     <link href="{{ asset(Module::getPublicPath(AMEISE_MODULE) . '/css/awesomplete.css') }}" rel="stylesheet"

--- a/Resources/views/partials/crm_users.blade.php
+++ b/Resources/views/partials/crm_users.blade.php
@@ -1,7 +1,7 @@
 <link href="{{ asset(Module::getPublicPath(AMEISE_MODULE) . '/css/style.css') }}" rel="stylesheet" type="text/css">
 @section('javascripts')
     @parent
-    <input type="hidden" id="ameise_base_url" value="{{ (config('ameisemodule.ameise_mode') == 'test' ? 'https://maklerinfo.inte.dionera.dev/' : 'https://www.maklerinfo.biz/') }}">
+    <input type="hidden" id="ameise_base_url" value="{{ (config('ameisemodule.ameise_mode') == 'test' ? 'https://maklerinfo.inte.dionera.dev/' : 'https://ameise.app/') }}">
     <script src="{{ Module::getPublicPath(AMEISE_MODULE) . '/js/crm_users.js' }}"  {!! \Helper::cspNonceAttr() !!}></script>
     <script  {!! \Helper::cspNonceAttr() !!}>
             let translations = {


### PR DESCRIPTION
### Motivation
- Replace hardcoded production domain `www.maklerinfo.biz` with the new domain `ameise.app` in UI partials so portal links and base URLs point to the correct host.

### Description
- Updated `Resources/views/partials/crm_users.blade.php` to set the hidden `ameise_base_url` value to `https://ameise.app/` for production mode.
- Updated `Resources/views/partials/conversation_button.blade.php` to set the hidden `ameise_base_url` value to `https://ameise.app/` for production mode.
- Updated `Resources/views/partials/contracts.blade.php` to use `https://ameise.app` for the customer portal `href` while leaving the test inte domain unchanged.

### Testing
- Ran `rg -n "www\.maklerinfo\.biz" Resources/views/partials` to confirm replacements and found no remaining matches in those partials.
- Inspected the updated files with `nl -ba` to verify the new `ameise.app` values are present and correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9b26e284832785082c1b5e702543)