### PR TITLE
Prefill CRM user search from conversation email, add POST API helper, and enhance autocomplete UX

### DIFF
--- a/Http/Controllers/AmeiseController.php
+++ b/Http/Controllers/AmeiseController.php
@@ -133,7 +133,23 @@ class AmeiseController extends Controller
 
     private function getCrmUsers($inputs, $result = [])
     {
-        $response = $this->apiClient->fetchUserByIdOrName($inputs['search']);
+        $response = [];
+        if (!empty($inputs['search_by_mail']) && !empty($inputs['conversation_id'])) {
+            $conversation = Conversation::find($inputs['conversation_id']);
+            if (!empty($conversation->customer_email)) {
+                $response = $this->apiClient->fetchUserByEmail($conversation->customer_email);
+            }
+        }
+
+        if (empty($response)) {
+            $search = trim($inputs['search'] ?? '');
+            if ($search === '') {
+                $result['crmUsers'] = [];
+                return response()->json($result);
+            }
+            $response = $this->apiClient->fetchUserByIdOrName($search);
+        }
+
         if (isset($response['error']) && isset($response['url'])) {
             return response()->json(['error' => 'Redirect', 'url' => $response['url']]);
         }

--- a/Public/js/crm.js
+++ b/Public/js/crm.js
@@ -7,8 +7,50 @@ $(document).ready(function() {
         const archive_btn = $('#archive_btn');
 
         const input = document.getElementById('crm_user');
-        const awesomeList = new Awesomplete(input, { });
+        const awesomeList = new Awesomplete(input, {
+            minChars: 0,
+            autoFirst: true
+        });
         let dataList = [];
+
+        function applySuggestions(data) {
+            dataList = data.crmUsers || [];
+            searchIcon.hide();
+            const suggestions = dataList.map(item => ({
+                id: item.id,
+                text: item.text
+            }));
+            input.setAttribute('data-list', suggestions.map(item => item.text).join(','));
+            awesomeList.list = suggestions.map(item => item.text);
+            awesomeList.evaluate();
+        }
+
+        function loadSuggestionsByConversationEmail() {
+            const conversationId = document.body.getAttribute('data-conversation_id');
+            if (!conversationId) {
+                return;
+            }
+            searchIcon.show();
+            fetch("/ameise/ajax", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                body: `search=&search_by_mail=1&conversation_id=${encodeURIComponent(conversationId)}&action=crm_users_search&_token=${encodeURIComponent(csrfToken)}`,
+            })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.error === 'Redirect') {
+                        window.open(data.url, '_blank');
+                        return;
+                    }
+                    applySuggestions(data);
+                })
+                .catch(() => searchIcon.hide());
+        }
+
+        loadSuggestionsByConversationEmail();
+
         input.addEventListener('input', function () {
         searchIcon.show();
         const inputValue = input.value;
@@ -26,15 +68,7 @@ $(document).ready(function() {
                     window.open(data.url, '_blank');
 
                 } else {
-                    dataList = data.crmUsers;
-                    searchIcon.hide();
-                    const suggestions = dataList.map(item => ({
-                        id: item.id, // Assuming "id" is the property containing the ID
-                        text: item.text // Assuming "text" is the property containing the text
-                    }));
-                    input.setAttribute('data-list', suggestions.map(item => item.text).join(','));
-                    awesomeList.list = suggestions.map(item => item.text);
-                    awesomeList.evaluate();
+                    applySuggestions(data);
                 }
             })
             .catch(error => $('#result').html('An error occurred while fetching data.'));

--- a/Services/CrmApiClient.php
+++ b/Services/CrmApiClient.php
@@ -74,6 +74,46 @@ class CrmApiClient
         return [];
     }
 
+    private function apiPost($path, $logContext, array $options = [], $errorReturn = [], $useBaseOnly = false)
+    {
+        try {
+            $tokenError = $this->checkTokenError();
+            if ($tokenError) {
+                return $tokenError;
+            }
+            $url = $useBaseOnly ? $this->base_url . $path : $this->maUrl($path);
+            $this->ameiseLogStatus && \Helper::log($logContext, 'Sending POST request to: ' . $url);
+            $requestOptions = array_merge([
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $this->getAccessToken(),
+                ],
+            ], $options);
+            $response = $this->client->post($url, $requestOptions);
+            $this->ameiseLogStatus && \Helper::log($logContext, 'Response status: ' . $response->getStatusCode());
+            if ($response->getStatusCode() === 200) {
+                return json_decode($response->getBody(), true);
+            } elseif ($response->getStatusCode() === 401) {
+                $this->tokenService->disconnectAmeise();
+            } else {
+                $errorResponse = json_decode($response->getBody(), true);
+                $this->ameiseLogStatus && \Helper::log($logContext, 'Request failed with status code: ' . $response->getStatusCode());
+                $this->ameiseLogStatus && \Helper::log($logContext, 'Error response: ' . json_encode($errorResponse));
+            }
+            $this->ameiseLogStatus && \Helper::log($logContext, 'Request completed.');
+        } catch (Exception $e) {
+            $this->ameiseLogStatus && \Helper::logException($e, $logContext);
+            if ($e->getCode() === 401) {
+                $this->tokenService->disconnectAmeise();
+            }
+            if ($e->hasResponse()) {
+                $body = (string) $e->getResponse()->getBody();
+                $this->ameiseLogStatus && \Helper::log($logContext, 'Error body: ' . $body);
+            }
+            return $errorReturn;
+        }
+        return [];
+    }
+
     private function maUrl($path)
     {
         return $this->base_url . $this->tokenService->getMa() . '/' . $path;
@@ -98,9 +138,19 @@ class CrmApiClient
 
     public function fetchUserByEmail($email)
     {
-        return $this->apiGet(
+        $response = $this->apiPost(
             'kunden/_search',
             'fetch_user_email',
+            ['json' => ['mail' => $email]]
+        );
+
+        if (!empty($response)) {
+            return $response;
+        }
+
+        return $this->apiGet(
+            'kunden/_search',
+            'fetch_user_email_fallback',
             ['query' => ['mail' => $email]]
         );
     }


### PR DESCRIPTION
### Motivation
- Enable finding CRM users by the conversation's customer email to surface likely matches without typed input.
- Add a reusable POST helper to the CRM API client to support endpoints that expect JSON payloads.
- Improve autocomplete behavior and avoid unnecessary API calls for empty searches.

### Description
- Updated `AmeiseController::getCrmUsers` to attempt `fetchUserByEmail` when `search_by_mail` and `conversation_id` are provided, falling back to `fetchUserByIdOrName` and returning an empty `crmUsers` list for empty search input. 
- Added `apiPost` helper to `Services/CrmApiClient.php` that centralizes POST requests, token checks and logging, and updated `fetchUserByEmail` to call it first with a JSON body then fallback to a query GET if empty.
- Enhanced frontend autocomplete in `Public/js/crm.js` by configuring `Awesomplete` with `minChars: 0` and `autoFirst: true`, introducing `applySuggestions` to populate suggestions, and adding `loadSuggestionsByConversationEmail` to prefetch suggestions using the conversation's email on modal open.
- Preserved existing redirect/error handling for API responses and ensured the UI hides the loading icon on errors or after suggestions are applied.

### Testing
- Ran PHP unit tests with `phpunit` against the existing test suite and they passed.
- Executed JavaScript checks with `npm run test` (including lint/tests) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9e0131808327aa08ab87a56fc595)