### PR TITLE
Sanitize token-related logging in TokenService and CrmApiClient

### DIFF
--- a/Services/CrmApiClient.php
+++ b/Services/CrmApiClient.php
@@ -57,7 +57,10 @@ class CrmApiClient
             } else {
                 $errorResponse = json_decode($response->getBody(), true);
                 $this->ameiseLogStatus && \Helper::log($logContext, 'Request failed with status code: ' . $response->getStatusCode());
-                $this->ameiseLogStatus && \Helper::log($logContext, 'Error response: ' . json_encode($errorResponse));
+                $this->ameiseLogStatus && \Helper::log(
+                    $logContext,
+                    'Error response: ' . json_encode($this->sanitizeLogData($errorResponse))
+                );
             }
             $this->ameiseLogStatus && \Helper::log($logContext, 'Request completed.');
         } catch (Exception $e) {
@@ -67,7 +70,7 @@ class CrmApiClient
             }
             if ($e->hasResponse()) {
                 $body = (string) $e->getResponse()->getBody();
-                $this->ameiseLogStatus && \Helper::log($logContext, 'Error body: ' . $body);
+                $this->ameiseLogStatus && \Helper::log($logContext, 'Error body: ' . $this->sanitizeLogText($body));
             }
             return $errorReturn;
         }
@@ -97,7 +100,10 @@ class CrmApiClient
             } else {
                 $errorResponse = json_decode($response->getBody(), true);
                 $this->ameiseLogStatus && \Helper::log($logContext, 'Request failed with status code: ' . $response->getStatusCode());
-                $this->ameiseLogStatus && \Helper::log($logContext, 'Error response: ' . json_encode($errorResponse));
+                $this->ameiseLogStatus && \Helper::log(
+                    $logContext,
+                    'Error response: ' . json_encode($this->sanitizeLogData($errorResponse))
+                );
             }
             $this->ameiseLogStatus && \Helper::log($logContext, 'Request completed.');
         } catch (Exception $e) {
@@ -107,7 +113,7 @@ class CrmApiClient
             }
             if ($e->hasResponse()) {
                 $body = (string) $e->getResponse()->getBody();
-                $this->ameiseLogStatus && \Helper::log($logContext, 'Error body: ' . $body);
+                $this->ameiseLogStatus && \Helper::log($logContext, 'Error body: ' . $this->sanitizeLogText($body));
             }
             return $errorReturn;
         }
@@ -205,16 +211,67 @@ class CrmApiClient
             } else {
                 $errorResponse = json_decode($response->getBody(), true);
                 $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Request failed with status code: ' . $response->getStatusCode());
-                $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Error response: ' . json_encode($errorResponse));
+                $this->ameiseLogStatus && \Helper::log(
+                    'conversation_archive',
+                    'Error response: ' . json_encode($this->sanitizeLogData($errorResponse))
+                );
             }
         } catch (Exception $e) {
             $body = $e->hasResponse() ? (string) $e->getResponse()->getBody() : '';
-            $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Error body: ' . $body);
+            $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Error body: ' . $this->sanitizeLogText($body));
             $this->ameiseLogStatus && \Helper::logException($e, 'conversation_archive');
             if ($e->getCode() === 401) {
                 $this->tokenService->disconnectAmeise();
             }
         }
         return false;
+    }
+
+    private function sanitizeLogData($data)
+    {
+        if (is_array($data)) {
+            $sanitized = [];
+            foreach ($data as $key => $value) {
+                if (is_string($key) && $this->isSensitiveKey($key)) {
+                    $sanitized[$key] = $this->valueFingerprint($value);
+                    continue;
+                }
+                $sanitized[$key] = $this->sanitizeLogData($value);
+            }
+            return $sanitized;
+        }
+
+        if (is_object($data)) {
+            return $this->sanitizeLogData((array) $data);
+        }
+
+        if (is_string($data)) {
+            return $this->sanitizeLogText($data);
+        }
+
+        return $data;
+    }
+
+    private function sanitizeLogText(string $text): string
+    {
+        $pattern = '/(Bearer\s+)([A-Za-z0-9\-\._~\+\/]+=*)/i';
+        return preg_replace_callback($pattern, function (array $matches) {
+            return $matches[1] . $this->valueFingerprint($matches[2]);
+        }, $text) ?? $text;
+    }
+
+    private function isSensitiveKey(string $key): bool
+    {
+        $normalized = strtolower($key);
+        return in_array($normalized, ['access_token', 'refresh_token', 'id_token', 'authorization', 'token'], true);
+    }
+
+    private function valueFingerprint($value): string
+    {
+        if (!is_string($value) || $value === '') {
+            return '[redacted]';
+        }
+
+        return '[fingerprint:sha256:' . substr(hash('sha256', $value), 0, 12) . ']';
     }
 }

--- a/Services/TokenService.php
+++ b/Services/TokenService.php
@@ -75,7 +75,10 @@ class TokenService
                 $tokens = json_decode(file_get_contents(storage_path($this->file)));
                 $this->access_token = $tokens->access_token ?? '';
             }
-            $this->ameiseLogStatus && \Helper::log('token_end_point', 'Access token retrieved successfully.' . $this->access_token);
+            $this->ameiseLogStatus && \Helper::log(
+                'token_end_point',
+                'Access token retrieved successfully. Fingerprint: ' . $this->tokenFingerprint($this->access_token)
+            );
             return $this->access_token;
         } catch (\Exception $e) {
             $this->ameiseLogStatus && \Helper::logException($e, 'token_end_point');
@@ -163,7 +166,10 @@ class TokenService
     {
         try {
             $tokens = json_decode(file_get_contents(storage_path($this->file)));
-            $this->ameiseLogStatus && \Helper::log('user_info', 'Sending a userinfo request with access token: ' . $this->access_token);
+            $this->ameiseLogStatus && \Helper::log(
+                'user_info',
+                'Sending a userinfo request with access token fingerprint: ' . $this->tokenFingerprint($this->access_token)
+            );
             $client = new Client();
             $response = $client->get($this->url . '/userinfo', [
                 'headers' => [
@@ -231,5 +237,14 @@ class TokenService
     public function getMa()
     {
         return $this->ma;
+    }
+
+    private function tokenFingerprint(?string $token): string
+    {
+        if (empty($token)) {
+            return '[empty]';
+        }
+
+        return 'sha256:' . substr(hash('sha256', $token), 0, 12);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent sensitive tokens from being logged in plaintext by replacing direct token output with deterministic fingerprints. 
- Ensure all `\Helper::log` calls in token-related flows are reviewed and no longer expose `access_token`, `refresh_token`, Bearer headers or similar secrets. 
- Provide a small, safe sanitization layer for API error payloads and response bodies so logs remain useful while avoiding secret leakage. 

### Description
- Replaced plaintext token logging in `TokenService::getAccessToken` and `TokenService::userInfo` with a SHA-256 based short fingerprint via the new `tokenFingerprint()` helper. 
- Added sanitization helpers to `CrmApiClient`: `sanitizeLogData()`, `sanitizeLogText()`, `isSensitiveKey()` and `valueFingerprint()` and updated error/body logging to use these helpers. 
- `sanitizeLogText()` masks Bearer tokens embedded in free text and `sanitizeLogData()` recursively redacts sensitive JSON/object keys like `access_token`, `refresh_token`, `id_token`, `authorization` and `token`. 
- Updated `CrmApiClient` error logging sites to emit sanitized output instead of raw responses or bodies, while preserving existing `logException` usage. 

### Testing
- Ran syntax checks with `php -l Services/TokenService.php` which succeeded. 
- Ran syntax checks with `php -l Services/CrmApiClient.php` which succeeded. 
- Performed an automated backfill scan command (`if [ -d storage/logs ]; then rg -n "(access_token|refresh_token|Bearer\\s+[A-Za-z0-9\\-\\._~\\+/]+=*)" storage/logs || true; else echo "storage/logs not found"; fi`) and observed there is no `storage/logs` directory in this environment, so no existing-log rotation/backfill was possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb027d46c8327be1529be975f2779)