### PR TITLE
Add customer-number fallback for CRM archive suggestions

### DIFF
--- a/Http/Controllers/AmeiseController.php
+++ b/Http/Controllers/AmeiseController.php
@@ -139,6 +139,12 @@ class AmeiseController extends Controller
             if (!empty($conversation->customer_email)) {
                 $response = $this->apiClient->fetchUserByEmail($conversation->customer_email);
             }
+            if (empty($response) && $conversation) {
+                $customerNumber = $this->extractCustomerNumberFromConversation($conversation);
+                if (!empty($customerNumber)) {
+                    $response = $this->apiClient->fetchUserByIdOrName($customerNumber);
+                }
+            }
         }
 
         if (empty($response)) {
@@ -180,6 +186,41 @@ class AmeiseController extends Controller
         }
         $result['crmUsers'] = $crmUsers;
         return response()->json($result);
+    }
+
+    private function extractCustomerNumberFromConversation($conversation)
+    {
+        $searchableTexts = [];
+        if (!empty($conversation->subject)) {
+            $searchableTexts[] = $conversation->subject;
+        }
+
+        foreach ($conversation->threads as $thread) {
+            if (!empty($thread->body)) {
+                $searchableTexts[] = $thread->body;
+            }
+        }
+
+        foreach ($searchableTexts as $text) {
+            $customerNumber = $this->extractCustomerNumber((string) $text);
+            if (!empty($customerNumber)) {
+                return $customerNumber;
+            }
+        }
+
+        return null;
+    }
+
+    private function extractCustomerNumber($text)
+    {
+        $normalizedText = html_entity_decode($text, ENT_QUOTES | ENT_HTML5);
+        $normalizedText = strip_tags($normalizedText);
+
+        if (preg_match('/\b5\d{9}\b/', $normalizedText, $matches) === 1) {
+            return $matches[0];
+        }
+
+        return null;
     }
 
     private function getFSUsers($inputs)


### PR DESCRIPTION
### Motivation
- Bei der Archivierung werden derzeit Vorschläge anhand der E-Mail-Adresse gesucht; wenn kein Vorschlag gefunden wird, soll zusätzlich in Betreff und Inhalt der Konversation nach einer Kundennummer gesucht werden. 
- Kundennummern sind immer zehnstellig, numerisch und beginnen mit einer `5`, daher soll diese Form erkannt und zur CRM-Suche verwendet werden.

### Description
- Erweiterung von `getCrmUsers()`: nachdem `fetchUserByEmail()` keine Treffer liefert, wird `extractCustomerNumberFromConversation()` aufgerufen und bei Fund `fetchUserByIdOrName()` mit der Kundennummer ausgeführt. 
- Hinzugefügt: `extractCustomerNumberFromConversation()` zum Scannen von `subject` und allen `threads`-Bodies der Konversation. 
- Hinzugefügt: `extractCustomerNumber()` normalisiert HTML mit `html_entity_decode()` und `strip_tags()` und extrahiert die Kundennummer via Regex `\b5\d{9}\b`.

### Testing
- Syntax-Check mit `php -l Http/Controllers/AmeiseController.php` wurde ausgeführt und meldet "No syntax errors detected".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfabf8c9148327a8360ddfeb0c6ab5)