### PR TITLE
Search full email HTML for customer numbers

### DIFF
--- a/Http/Controllers/AmeiseController.php
+++ b/Http/Controllers/AmeiseController.php
@@ -135,7 +135,7 @@ class AmeiseController extends Controller
     {
         $response = [];
         if (!empty($inputs['search_by_mail']) && !empty($inputs['conversation_id'])) {
-            $conversation = Conversation::find($inputs['conversation_id']);
+            $conversation = Conversation::with('threads')->find($inputs['conversation_id']);
             if (!empty($conversation->customer_email)) {
                 $response = $this->apiClient->fetchUserByEmail($conversation->customer_email);
                 if (isset($response['error']) && isset($response['url'])) {
@@ -225,10 +225,21 @@ class AmeiseController extends Controller
 
     private function extractCustomerNumbers($text)
     {
-        $normalizedText = html_entity_decode($text, ENT_QUOTES | ENT_HTML5);
-        $normalizedText = strip_tags($normalizedText);
+        $decodedText = html_entity_decode($text, ENT_QUOTES | ENT_HTML5);
+        $decodedUrlText = rawurldecode($decodedText);
+        $plainText = strip_tags($decodedText);
 
-        if (preg_match_all('/\b5\d{9}\b/', $normalizedText, $matches) > 0) {
+        // Search both the rendered text and the original HTML so customer numbers
+        // in signatures, hidden spans, or link attributes (for example kid=...)
+        // are detected.
+        $searchableText = implode(' ', array_unique([
+            $text,
+            $decodedText,
+            $decodedUrlText,
+            $plainText,
+        ]));
+
+        if (preg_match_all('/(?<!\d)5\d{9}(?!\d)/', $searchableText, $matches) > 0) {
             return array_values(array_unique($matches[0]));
         }
 


### PR DESCRIPTION
### Motivation
- Kundennummern in E‑Mail-Signaturen, versteckten Span-Elementen oder Link-Parametern (z.B. `kid=`) wurden nicht zuverlässig gefunden; die Suche muss den vollständigen E‑Mail‑HTML‑Inhalt abdecken.
- Threads der Conversation sollten beim Lookup geladen werden, um sicherzustellen, dass alle Thread‑Bodies verfügbar sind und geprüft werden können.

### Description
- Lade die Conversation explizit mit Threads mittels `Conversation::with('threads')->find(...)` bevor Kundennummern extrahiert werden.
- Ersetze die einfache Normalisierung durch eine kombinierte Suche über Roh‑HTML, HTML‑dekodierten Text, URL‑dekodierten Text und sichtbaren Plaintext und vereine diese in einem `searchableText`-String vor der Suche.
- Aktualisiere das Matching auf einen robusteren Regex mit Lookarounds `/(?<!\d)5\d{9}(?!\d)/` um false positives an Wortgrenzen zu reduzieren.
- Kein weiteres Verhalten wurde verändert; Änderungen beschränken sich auf `Http/Controllers/AmeiseController.php`.

### Testing
- `php -l Http/Controllers/AmeiseController.php` wurde ausgeführt und zeigte keine Syntaxfehler.
- Ein PHP‑Einzeiler, der das Beispiel‑Signature‑HTML simuliert, verifiziert, dass `5002970262` extrahiert wird, und lief erfolgreich.
- `git diff --check` wurde ausgeführt und beanstandete keine Probleme.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03bd0ef1088327b125d90b70df32b5)