### PR TITLE
Add comprehensive archive attempt tracking and retry mechanism

### DIFF
--- a/Console/Commands/ArchiveThreads.php
+++ b/Console/Commands/ArchiveThreads.php
@@ -6,41 +6,24 @@ use App\Thread;
 use App\User;
 use Illuminate\Console\Command;
 use Modules\AmeiseModule\Entities\CrmArchive;
+use Modules\AmeiseModule\Entities\CrmArchiveAttempt;
 use Modules\AmeiseModule\Entities\CrmArchiveThread;
 use Modules\AmeiseModule\Jobs\ArchiveThreadsJob;
 
 class ArchiveThreads extends Command
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
     protected $signature = 'ameise:archive-threads';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
     protected $description = 'Archiviere neue Threads ins CRM für alle Nutzer, die die Konversation archiviert haben';
 
-    /**
-     * Create a new command instance.
-     */
     public function __construct()
     {
         parent::__construct();
     }
 
-    /**
-     * Execute the console command.
-     */
     public function handle()
     {
-        // IDs aller archivierten Konversationen
         $conversationIds = CrmArchiveThread::distinct()->pluck('conversation_id')->toArray();
-        // IDs aller Threads, die bereits archiviert wurden
         $threadIds = CrmArchiveThread::distinct()->pluck('thread_id')->toArray();
 
         $threads = Thread::select('threads.*')
@@ -50,6 +33,7 @@ class ArchiveThreads extends Command
             ->with(['conversation', 'attachments'])
             ->get();
 
+        $dispatched = 0;
         foreach ($threads as $thread) {
             $archives = CrmArchive::where('conversation_id', $thread->conversation_id)
                 ->groupBy('archived_by')
@@ -59,9 +43,20 @@ class ArchiveThreads extends Command
             $users = User::whereIn('id', $archives)->get();
 
             foreach ($users as $user) {
-                // Dispatch des Jobs
                 ArchiveThreadsJob::dispatch($thread->conversation, $thread, $user);
+                $dispatched++;
             }
         }
+
+        $pendingFailures = CrmArchiveAttempt::whereIn('status', CrmArchiveAttempt::FAILURE_STATUSES)
+            ->whereNull('resolved_at')
+            ->count();
+
+        $this->info(sprintf(
+            'ameise:archive-threads dispatched=%d threads=%d unresolved_failures=%d',
+            $dispatched,
+            $threads->count(),
+            $pendingFailures
+        ));
     }
 }

--- a/Console/Commands/ListFailedArchives.php
+++ b/Console/Commands/ListFailedArchives.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Modules\AmeiseModule\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Modules\AmeiseModule\Entities\CrmArchiveAttempt;
+
+class ListFailedArchives extends Command
+{
+    protected $signature = 'ameise:list-failed-archives {--since=30d : Zeitraum, z. B. 24h, 7d, 30d} {--status= : Filter auf einen konkreten Status}';
+
+    protected $description = 'Listet unaufgeloeste Archivierungs-Fehlversuche aus crm_archive_attempts';
+
+    public function handle()
+    {
+        $since = $this->parseSince((string) $this->option('since'));
+        $status = $this->option('status');
+
+        $query = CrmArchiveAttempt::whereNull('resolved_at')
+            ->whereIn('status', CrmArchiveAttempt::FAILURE_STATUSES)
+            ->where('created_at', '>=', $since);
+
+        if ($status) {
+            $query->where('status', $status);
+        }
+
+        $attempts = $query->orderBy('created_at', 'desc')->get();
+
+        if ($attempts->isEmpty()) {
+            $this->info('Keine offenen Fehlversuche im Zeitraum.');
+            return 0;
+        }
+
+        $rows = $attempts->map(function ($a) {
+            return [
+                'id' => $a->id,
+                'conv' => $a->conversation_id,
+                'thread' => $a->thread_id,
+                'user' => $a->user_id,
+                'status' => $a->status,
+                'try' => $a->attempt_no,
+                'reason' => mb_strimwidth((string) $a->reason, 0, 60, '...'),
+                'when' => $a->created_at ? $a->created_at->toDateTimeString() : '',
+            ];
+        })->all();
+
+        $this->table(['ID', 'Conv', 'Thread', 'User', 'Status', 'Try', 'Reason', 'Created'], $rows);
+        $this->info(sprintf('%d offene Fehlversuche.', $attempts->count()));
+
+        return 0;
+    }
+
+    private function parseSince(string $since): Carbon
+    {
+        if (preg_match('/^(\d+)\s*([hd])$/i', trim($since), $m)) {
+            $n = (int) $m[1];
+            return strtolower($m[2]) === 'h' ? Carbon::now()->subHours($n) : Carbon::now()->subDays($n);
+        }
+        return Carbon::now()->subDays(30);
+    }
+}

--- a/Console/Commands/RetryFailedArchives.php
+++ b/Console/Commands/RetryFailedArchives.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Modules\AmeiseModule\Console\Commands;
+
+use App\Conversation;
+use App\Thread;
+use App\User;
+use Illuminate\Console\Command;
+use Modules\AmeiseModule\Entities\CrmArchiveAttempt;
+use Modules\AmeiseModule\Jobs\ArchiveThreadsJob;
+
+class RetryFailedArchives extends Command
+{
+    protected $signature = 'ameise:retry-failed-archives
+        {--id=* : crm_archive_attempts.id, mehrfach erlaubt}
+        {--conversation=* : conversation_id, mehrfach erlaubt}
+        {--all : Alle offenen Fehlversuche erneut anstossen}';
+
+    protected $description = 'Setzt fehlgeschlagene Archivierungen erneut in die Queue (ArchiveThreadsJob)';
+
+    public function handle()
+    {
+        $ids = $this->option('id');
+        $conversationIds = $this->option('conversation');
+        $all = (bool) $this->option('all');
+
+        if (!$ids && !$conversationIds && !$all) {
+            $this->error('Bitte --id, --conversation oder --all angeben.');
+            return 1;
+        }
+
+        $query = CrmArchiveAttempt::whereNull('resolved_at')
+            ->whereIn('status', CrmArchiveAttempt::FAILURE_STATUSES);
+        if ($ids) {
+            $query->whereIn('id', $ids);
+        } elseif ($conversationIds) {
+            $query->whereIn('conversation_id', $conversationIds);
+        }
+
+        $attempts = $query->get();
+        if ($attempts->isEmpty()) {
+            $this->info('Keine passenden Fehlversuche gefunden.');
+            return 0;
+        }
+
+        $dispatched = 0;
+        $seen = [];
+        foreach ($attempts as $attempt) {
+            $key = $attempt->thread_id . '-' . $attempt->user_id;
+            if (isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+
+            $thread = Thread::find($attempt->thread_id);
+            $conversation = Conversation::find($attempt->conversation_id);
+            $user = User::find($attempt->user_id);
+            if (!$thread || !$conversation || !$user) {
+                $this->warn(sprintf('Skip attempt %d: thread/conversation/user fehlt', $attempt->id));
+                continue;
+            }
+
+            ArchiveThreadsJob::dispatch($conversation, $thread, $user);
+            CrmArchiveAttempt::record([
+                'conversation_id' => $conversation->id,
+                'thread_id' => $thread->id,
+                'user_id' => $user->id,
+                'status' => CrmArchiveAttempt::STATUS_PENDING,
+                'reason' => 'Manuell neu eingereiht via CLI',
+            ]);
+            $dispatched++;
+        }
+
+        $this->info(sprintf('%d Job(s) erneut eingereiht.', $dispatched));
+        return 0;
+    }
+}

--- a/Database/Migrations/2026_06_16_000000_create_crm_archive_attempts_table.php
+++ b/Database/Migrations/2026_06_16_000000_create_crm_archive_attempts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateCrmArchiveAttemptsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('crm_archive_attempts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('conversation_id')->index();
+            $table->unsignedBigInteger('thread_id')->index();
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->string('status', 40);
+            $table->text('reason')->nullable();
+            $table->unsignedSmallInteger('http_status')->nullable();
+            $table->text('response_body')->nullable();
+            $table->unsignedSmallInteger('attempt_no')->default(1);
+            $table->unsignedSmallInteger('attachments_total')->nullable();
+            $table->unsignedSmallInteger('attachments_failed')->nullable();
+            $table->timestamp('next_retry_at')->nullable();
+            $table->timestamp('resolved_at')->nullable()->index();
+            $table->timestamps();
+
+            $table->index(['thread_id', 'user_id']);
+            $table->index(['status', 'resolved_at']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('crm_archive_attempts');
+    }
+}

--- a/Entities/CrmArchiveAttempt.php
+++ b/Entities/CrmArchiveAttempt.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Modules\AmeiseModule\Entities;
+
+use App\Conversation;
+use App\Thread;
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+
+class CrmArchiveAttempt extends Model
+{
+    const STATUS_SUCCESS = 'success';
+    const STATUS_PENDING = 'pending';
+    const STATUS_FAILED_NO_CUSTOMER = 'failed_no_customer';
+    const STATUS_FAILED_AMBIGUOUS_CUSTOMER = 'failed_ambiguous_customer';
+    const STATUS_FAILED_API = 'failed_api';
+    const STATUS_FAILED_TOKEN = 'failed_token';
+    const STATUS_FAILED_ATTACHMENT = 'failed_attachment';
+    const STATUS_FAILED_EXCEPTION = 'failed_exception';
+
+    const FAILURE_STATUSES = [
+        self::STATUS_FAILED_NO_CUSTOMER,
+        self::STATUS_FAILED_AMBIGUOUS_CUSTOMER,
+        self::STATUS_FAILED_API,
+        self::STATUS_FAILED_TOKEN,
+        self::STATUS_FAILED_ATTACHMENT,
+        self::STATUS_FAILED_EXCEPTION,
+    ];
+
+    protected $table = 'crm_archive_attempts';
+    protected $guarded = ['id'];
+    protected $dates = ['next_retry_at', 'resolved_at', 'created_at', 'updated_at'];
+
+    public function conversation()
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+
+    public function thread()
+    {
+        return $this->belongsTo(Thread::class, 'thread_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public static function record(array $data): self
+    {
+        $threadId = $data['thread_id'] ?? null;
+        $userId = $data['user_id'] ?? null;
+
+        $maxAttempt = static::where('thread_id', $threadId)
+            ->where('user_id', $userId)
+            ->max('attempt_no');
+
+        $data['attempt_no'] = (int) ($maxAttempt ?? 0) + 1;
+
+        $attempt = static::create($data);
+
+        if (($data['status'] ?? null) === self::STATUS_SUCCESS) {
+            static::where('thread_id', $threadId)
+                ->where('user_id', $userId)
+                ->whereNull('resolved_at')
+                ->where('id', '!=', $attempt->id)
+                ->update(['resolved_at' => now()]);
+        }
+
+        return $attempt;
+    }
+}

--- a/Http/Controllers/AmeiseController.php
+++ b/Http/Controllers/AmeiseController.php
@@ -12,7 +12,10 @@ use Modules\AmeiseModule\Services\TokenService;
 use Modules\AmeiseModule\Services\CrmApiClient;
 use Modules\AmeiseModule\Services\ConversationArchiver;
 use Modules\AmeiseModule\Entities\CrmArchive;
+use Modules\AmeiseModule\Entities\CrmArchiveAttempt;
 use Modules\AmeiseModule\Entities\CrmArchiveThread;
+use Modules\AmeiseModule\Jobs\ArchiveThreadsJob;
+use App\User;
 
 class AmeiseController extends Controller
 {
@@ -259,6 +262,48 @@ class AmeiseController extends Controller
         }
 
         return array_values($uniqueUsers);
+    }
+
+    public function retryArchiveAttempt($id)
+    {
+        $attempt = CrmArchiveAttempt::find($id);
+        if (!$attempt) {
+            return response()->json(['status' => 'not_found'], 404);
+        }
+
+        $thread = Thread::find($attempt->thread_id);
+        $conversation = Conversation::find($attempt->conversation_id);
+        $user = User::find($attempt->user_id);
+
+        if (!$thread || !$conversation || !$user) {
+            return response()->json(['status' => 'missing_relations'], 422);
+        }
+
+        ArchiveThreadsJob::dispatch($conversation, $thread, $user);
+        CrmArchiveAttempt::record([
+            'conversation_id' => $conversation->id,
+            'thread_id' => $thread->id,
+            'user_id' => $user->id,
+            'status' => CrmArchiveAttempt::STATUS_PENDING,
+            'reason' => 'Manuell neu eingereiht aus Settings (Attempt #' . $attempt->id . ')',
+        ]);
+
+        return response()->json(['status' => 'queued']);
+    }
+
+    public function dismissArchiveAttempt($id)
+    {
+        $attempt = CrmArchiveAttempt::find($id);
+        if (!$attempt) {
+            return response()->json(['status' => 'not_found'], 404);
+        }
+
+        CrmArchiveAttempt::where('thread_id', $attempt->thread_id)
+            ->where('user_id', $attempt->user_id)
+            ->whereNull('resolved_at')
+            ->update(['resolved_at' => now()]);
+
+        return response()->json(['status' => 'dismissed']);
     }
 
     private function getFSUsers($inputs)

--- a/Http/routes.php
+++ b/Http/routes.php
@@ -6,5 +6,7 @@ Route::group(['middleware' => 'web', 'prefix' => \Helper::getSubdirectory(), 'na
     Route::post('/ameise/ajax', ['uses' => 'AmeiseController@ajax', 'laroute' => true])->name('ameise.ajax');
     Route::get('/ameise/refresh-token', ['uses' => 'AmeiseController@refreshToken'])->name('ameise.refresh');
     Route::get('/crm/auth', ['uses' => 'AmeiseModuleController@auth', 'laroute' => true])->name('crm.auth');
+    Route::post('/ameise/archive-attempts/{id}/retry', ['uses' => 'AmeiseController@retryArchiveAttempt'])->name('ameise.archive_attempts.retry');
+    Route::post('/ameise/archive-attempts/{id}/dismiss', ['uses' => 'AmeiseController@dismissArchiveAttempt'])->name('ameise.archive_attempts.dismiss');
 
 });

--- a/Jobs/ArchiveThreadsJob.php
+++ b/Jobs/ArchiveThreadsJob.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Modules\AmeiseModule\Entities\CrmArchiveAttempt;
 
 class ArchiveThreadsJob implements ShouldQueue
 {
@@ -15,30 +16,49 @@ class ArchiveThreadsJob implements ShouldQueue
     protected $conversation;
     protected $user;
     public $timeout = 120;
-    /**
-     * Create a new job instance.
-     *
-     * @return void
-     */
+    public $tries = 5;
+
     public function __construct($conversation, $thread, $user)
     {
         $this->conversation = $conversation;
         $this->thread = $thread;
         $this->user = $user;
     }
-   
-    /**
-     * Execute the job.
-     *
-     * @return void
-     */
+
+    public function backoff(): array
+    {
+        return [60, 300, 900, 3600, 14400];
+    }
+
     public function handle()
     {
-      config('ameisemodule.ameise_log_status') && \Helper::log('Ameise Cron Log', 'Job Dispatched For Thread ID: '.$this->thread->id.' Conversation ID: '.$this->conversation->id.' User ID: '.$this->user->id.'');
+        config('ameisemodule.ameise_log_status') && \Helper::log('Ameise Cron Log', 'Job Dispatched For Thread ID: '.$this->thread->id.' Conversation ID: '.$this->conversation->id.' User ID: '.$this->user->id.'');
 
-      $tokenService = new \Modules\AmeiseModule\Services\TokenService('', $this->user->id);
-      $apiClient = new \Modules\AmeiseModule\Services\CrmApiClient($tokenService);
-      $archiver = new \Modules\AmeiseModule\Services\ConversationArchiver($apiClient);
-      $archiver->archiveConversationData($this->conversation, $this->thread, $this->user);
+        try {
+            $tokenService = new \Modules\AmeiseModule\Services\TokenService('', $this->user->id);
+            $apiClient = new \Modules\AmeiseModule\Services\CrmApiClient($tokenService);
+            $archiver = new \Modules\AmeiseModule\Services\ConversationArchiver($apiClient);
+            $archiver->archiveConversationData($this->conversation, $this->thread, $this->user);
+        } catch (\Throwable $e) {
+            CrmArchiveAttempt::record([
+                'conversation_id' => $this->conversation->id ?? null,
+                'thread_id' => $this->thread->id ?? null,
+                'user_id' => $this->user->id ?? null,
+                'status' => CrmArchiveAttempt::STATUS_FAILED_EXCEPTION,
+                'reason' => substr($e->getMessage(), 0, 1000),
+            ]);
+            throw $e;
+        }
+    }
+
+    public function failed(\Throwable $e)
+    {
+        CrmArchiveAttempt::record([
+            'conversation_id' => $this->conversation->id ?? null,
+            'thread_id' => $this->thread->id ?? null,
+            'user_id' => $this->user->id ?? null,
+            'status' => CrmArchiveAttempt::STATUS_FAILED_EXCEPTION,
+            'reason' => 'Final failure after ' . $this->tries . ' attempts: ' . substr($e->getMessage(), 0, 1000),
+        ]);
     }
 }

--- a/Providers/AmeiseModuleServiceProvider.php
+++ b/Providers/AmeiseModuleServiceProvider.php
@@ -10,6 +10,8 @@ use Config;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Event;
 use Modules\AmeiseModule\Console\Commands\ArchiveThreads;
+use Modules\AmeiseModule\Console\Commands\ListFailedArchives;
+use Modules\AmeiseModule\Console\Commands\RetryFailedArchives;
 defined('AMEISE_MODULE') || define('AMEISE_MODULE', 'ameisemodule');
 
 class AmeiseModuleServiceProvider extends ServiceProvider
@@ -33,6 +35,8 @@ class AmeiseModuleServiceProvider extends ServiceProvider
         $this->registerFactories();
         $this->commands([
             ArchiveThreads::class,
+            ListFailedArchives::class,
+            RetryFailedArchives::class,
         ]);
         $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
         $this->hooks();

--- a/README.md
+++ b/README.md
@@ -23,6 +23,27 @@ Verbose module logs (including Cron-Logeinträge) are disabled by default to avo
 ein übermäßiges Wachstum der `activity_logs`-Tabelle. Bei Bedarf können Sie sie
 über die Umgebungsvariable `AMEISE_LOG_STATUS=true` wieder aktivieren.
 
+## Tracking fehlgeschlagener Archivierungen
+Auch bei deaktiviertem `AMEISE_LOG_STATUS` werden Fehlversuche dauerhaft in der
+Tabelle `crm_archive_attempts` festgehalten (Grund, HTTP-Status, bereinigte
+Response). Konkrete Status:
+
+- `failed_no_customer` / `failed_ambiguous_customer` – kein eindeutiger Ameise-Kunde zur Mailadresse
+- `failed_api` – Ameise hat per HTTP gemeldet, dass die Archivierung nicht klappt
+- `failed_token` – Tokenfehler beim Aufruf
+- `failed_attachment` – Hauptnachricht ist angekommen, Anhänge teils nicht
+- `failed_exception` – unerwartete Exception (nach allen Queue-Retries endgültig)
+
+Tools:
+
+- CLI: `php artisan ameise:list-failed-archives [--since=24h] [--status=failed_api]`
+- CLI: `php artisan ameise:retry-failed-archives --conversation=123` oder `--id=456` oder `--all`
+- UI: Settings → Ameise → Sektion „Archivierungs-Fehler" listet offene Fälle mit „Erneut versuchen"/„Erledigt"-Buttons
+
+`ArchiveThreadsJob` versucht Exceptions automatisch bis zu 5×
+(Backoff 1 min / 5 min / 15 min / 1 h / 4 h) erneut; der Cron `ameise:archive-threads`
+greift offene Threads zusätzlich alle 5 Minuten wieder auf.
+
 ## Attachment Handling
 Image attachments are automatically converted to PDF before being archived.
 

--- a/Resources/views/settings.blade.php
+++ b/Resources/views/settings.blade.php
@@ -42,3 +42,95 @@
         </div>
     </div>
 </form>
+
+@php
+    $failedAttempts = \Modules\AmeiseModule\Entities\CrmArchiveAttempt::whereNull('resolved_at')
+        ->whereIn('status', \Modules\AmeiseModule\Entities\CrmArchiveAttempt::FAILURE_STATUSES)
+        ->where('created_at', '>=', \Carbon\Carbon::now()->subDays(30))
+        ->orderBy('created_at', 'desc')
+        ->limit(200)
+        ->get();
+@endphp
+
+<hr>
+<h3>{{ __('Archivierungs-Fehler (letzte 30 Tage)') }}</h3>
+<p class="text-muted">
+    {{ __('Hier erscheinen Threads, die laut Freescout archiviert wurden, in Ameise aber nicht angekommen sind. Cron versucht es alle 5 Minuten erneut; "Erneut versuchen" stoesst den Job sofort an, "Erledigt" markiert alle offenen Versuche fuer diesen Thread als geschlossen.') }}
+</p>
+@if($failedAttempts->isEmpty())
+    <p><em>{{ __('Keine offenen Fehlversuche.') }}</em></p>
+@else
+    <table class="table table-condensed" id="ameise-failed-attempts">
+        <thead>
+            <tr>
+                <th>{{ __('Konversation') }}</th>
+                <th>{{ __('Thread') }}</th>
+                <th>{{ __('User') }}</th>
+                <th>{{ __('Status') }}</th>
+                <th>{{ __('Versuch') }}</th>
+                <th>{{ __('Grund') }}</th>
+                <th>{{ __('Zeit') }}</th>
+                <th>{{ __('Aktion') }}</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach($failedAttempts as $attempt)
+            <tr data-attempt-id="{{ $attempt->id }}">
+                <td><a href="{{ route('conversations.view', ['id' => $attempt->conversation_id]) }}" target="_blank">#{{ $attempt->conversation_id }}</a></td>
+                <td>{{ $attempt->thread_id }}</td>
+                <td>{{ $attempt->user_id }}</td>
+                <td><code>{{ $attempt->status }}</code></td>
+                <td>{{ $attempt->attempt_no }}</td>
+                <td title="{{ $attempt->reason }}">{{ \Illuminate\Support\Str::limit($attempt->reason, 80) }}</td>
+                <td>{{ $attempt->created_at ? $attempt->created_at->diffForHumans() : '' }}</td>
+                <td>
+                    <button type="button" class="btn btn-xs btn-default ameise-retry-attempt" data-url="{{ route('ameise.archive_attempts.retry', ['id' => $attempt->id]) }}">{{ __('Erneut versuchen') }}</button>
+                    <button type="button" class="btn btn-xs btn-default ameise-dismiss-attempt" data-url="{{ route('ameise.archive_attempts.dismiss', ['id' => $attempt->id]) }}">{{ __('Erledigt') }}</button>
+                </td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+@endif
+
+<script>
+(function(){
+    var token = document.querySelector('meta[name="csrf-token"]');
+    var csrf = token ? token.getAttribute('content') : '{{ csrf_token() }}';
+    function postAction(url) {
+        return fetch(url, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'X-CSRF-TOKEN': csrf,
+                'Accept': 'application/json'
+            }
+        });
+    }
+    document.querySelectorAll('.ameise-retry-attempt').forEach(function(btn){
+        btn.addEventListener('click', function(){
+            var url = btn.getAttribute('data-url');
+            btn.disabled = true;
+            postAction(url).then(function(){
+                var row = btn.closest('tr');
+                if (row) { row.style.opacity = '0.5'; }
+                btn.innerText = '{{ __('Eingereiht') }}';
+            }).catch(function(){
+                btn.disabled = false;
+            });
+        });
+    });
+    document.querySelectorAll('.ameise-dismiss-attempt').forEach(function(btn){
+        btn.addEventListener('click', function(){
+            var url = btn.getAttribute('data-url');
+            btn.disabled = true;
+            postAction(url).then(function(){
+                var row = btn.closest('tr');
+                if (row && row.parentNode) { row.parentNode.removeChild(row); }
+            }).catch(function(){
+                btn.disabled = false;
+            });
+        });
+    });
+})();
+</script>

--- a/Services/ConversationArchiver.php
+++ b/Services/ConversationArchiver.php
@@ -6,6 +6,7 @@ use App\Conversation;
 use App\Thread;
 use Carbon\Carbon;
 use Modules\AmeiseModule\Entities\CrmArchive;
+use Modules\AmeiseModule\Entities\CrmArchiveAttempt;
 use Modules\AmeiseModule\Entities\CrmArchiveThread;
 
 class ConversationArchiver
@@ -65,7 +66,7 @@ class ConversationArchiver
         $body = preg_replace("/\r\n|\r/", "\n", $body);
         $body = preg_replace("/\n{3,}/", "\n\n", $body);
         $body = str_replace("\n", "\r\n", $body);
-        
+
         return [
             'type' =>  ($conversation->type == Conversation::TYPE_EMAIL) ? 'email' : 'telefon',
             'x-dio-metadaten' => $x_dio_metadaten,
@@ -81,19 +82,25 @@ class ConversationArchiver
         ];
     }
 
+    /**
+     * @return array{archived_ok: bool, total: int, failed: int, last_failure: ?array}
+     */
     public function archiveConversationWithAttachments($thread, $conversation_data, $user = null)
     {
         $allAttachments = $thread->attachments;
         $user = $user ?? auth()->user();
         $userTimezone = $user->timezone;
-        $allArchived = true;
+        $total = $allAttachments->count();
+        $failed = 0;
+        $lastFailure = null;
 
-        if ($allAttachments->count() > 0) {
+        if ($total > 0) {
             foreach ($allAttachments as $attachment) {
                 $path = storage_path("app/attachment/{$attachment['file_dir']}{$attachment['file_name']}");
                 if (!file_exists($path)) {
                     \Helper::log('conversation_archive', 'Attachment file not found: ' . $path);
-                    $allArchived = false;
+                    $failed++;
+                    $lastFailure = ['reason' => 'attachment_file_missing', 'detail' => $attachment['file_name'] ?? null];
                     continue;
                 }
                 $body = file_get_contents($path);
@@ -118,14 +125,27 @@ class ConversationArchiver
                     'X-Dio-Zuordnungen' => $conversation_data['X-Dio-Zuordnungen'],
                     'X-Dio-Datum' => Carbon::parse($thread->created_at)->setTimezone($userTimezone)->format('Y-m-d\\TH:i:s')
                 ];
-                if (!$this->apiClient->archiveConversation($attachmentData)) {
+                $result = $this->apiClient->archiveConversationDetailed($attachmentData);
+                if (!$result['ok']) {
                     \Helper::log('conversation_archive', 'Failed to archive attachment: ' . $subject);
-                    $allArchived = false;
+                    $failed++;
+                    $lastFailure = [
+                        'reason' => 'attachment_api_failed',
+                        'detail' => $subject,
+                        'http_status' => $result['http_status'],
+                        'body' => $result['body'],
+                        'exception' => $result['exception'],
+                    ];
                 }
             }
         }
 
-        return $allArchived;
+        return [
+            'archived_ok' => $failed === 0,
+            'total' => $total,
+            'failed' => $failed,
+            'last_failure' => $lastFailure,
+        ];
     }
 
     public function isScanOnly($conversation)
@@ -137,42 +157,122 @@ class ConversationArchiver
     {
         $thread =  $thread ?? $conversation->getLastThread();
         $user = $user ?? auth()->user();
-        if ($this->shouldArchiveThread($conversation, $thread)) {
-            $crmArchives = CrmArchive::where('conversation_id', $conversation->id)->get();
-            if (count($crmArchives) > 0) {
-                foreach ($crmArchives as $crmArchive) {
-                    $isArchiveThread = CrmArchiveThread::where('crm_archive_id', $crmArchive->id)->where('thread_id',$thread->id)->first();
-                    if(!$isArchiveThread){
-                        $contracts = !empty($crmArchive->contracts) ? json_decode($crmArchive->contracts, true) : [];
-                        $divisions = !empty($crmArchive->divisions) ? json_decode($crmArchive->divisions, true) : [];
-                        $conversation_data = $this->createConversationData($conversation, $crmArchive->crm_user_id, $contracts, $divisions, $thread, $user);
-                        $scanOnly = $this->isScanOnly($conversation);
-                        $archived = $scanOnly ? true : $this->apiClient->archiveConversation($conversation_data);
-                        $attachmentsArchived = $archived ? $this->archiveConversationWithAttachments($thread, $conversation_data, $user) : false;
-                        if($archived && (!$scanOnly || $attachmentsArchived)) {
-                            CrmArchiveThread::create(['crm_archive_id' => $crmArchive->id,'thread_id' => $thread->id,'conversation_id'=> $conversation->id ]);
-                        }
-                    }
-                }
-            } else {
-                $response = $this->apiClient->fetchUserByEmail($conversation->customer_email);
-                if (count($response) == 1) {
-                    $crm_user_id = $response[0]['Id'];
-                    $conversation_data  = $this->createConversationData($conversation, $crm_user_id, [], [], $thread, $user);
-                    $scanOnly = $this->isScanOnly($conversation);
-                    $archived = $scanOnly ? true : $this->apiClient->archiveConversation($conversation_data);
-                    $attachmentsArchived = $archived ? $this->archiveConversationWithAttachments($thread, $conversation_data, $user) : false;
-                    if($archived && (!$scanOnly || $attachmentsArchived)) {
-                        $crm_archive = CrmArchive::firstOrNew(['conversation_id' => $conversation->id, 'crm_user_id' => $crm_user_id,'archived_by' => $user->id]);
-                        $crm_archive->crm_user = json_encode(['id' => $crm_user_id, 'text' => $response[0]['Text']]);
-                        $crm_archive->contracts = null;
-                        $crm_archive->divisions = null;
-                        $crm_archive->save();
-                        CrmArchiveThread::create(['crm_archive_id' => $crm_archive->id,'thread_id' => $thread->id,'conversation_id'=> $conversation->id ]);
-                    }
-                }
-            }
+        if (!$this->shouldArchiveThread($conversation, $thread)) {
+            return;
         }
 
+        $crmArchives = CrmArchive::where('conversation_id', $conversation->id)->get();
+        if (count($crmArchives) > 0) {
+            foreach ($crmArchives as $crmArchive) {
+                $isArchiveThread = CrmArchiveThread::where('crm_archive_id', $crmArchive->id)->where('thread_id', $thread->id)->first();
+                if ($isArchiveThread) {
+                    continue;
+                }
+                $contracts = !empty($crmArchive->contracts) ? json_decode($crmArchive->contracts, true) : [];
+                $divisions = !empty($crmArchive->divisions) ? json_decode($crmArchive->divisions, true) : [];
+                $conversation_data = $this->createConversationData($conversation, $crmArchive->crm_user_id, $contracts, $divisions, $thread, $user);
+                $this->performArchive($conversation, $thread, $user, $crmArchive, $conversation_data);
+            }
+            return;
+        }
+
+        $response = $this->apiClient->fetchUserByEmail($conversation->customer_email);
+        if (count($response) === 1) {
+            $crm_user_id = $response[0]['Id'];
+            $conversation_data = $this->createConversationData($conversation, $crm_user_id, [], [], $thread, $user);
+            $crm_archive = CrmArchive::firstOrNew([
+                'conversation_id' => $conversation->id,
+                'crm_user_id' => $crm_user_id,
+                'archived_by' => $user->id,
+            ]);
+            $crm_archive->crm_user = json_encode(['id' => $crm_user_id, 'text' => $response[0]['Text']]);
+            $crm_archive->contracts = null;
+            $crm_archive->divisions = null;
+            $crm_archive->save();
+            $this->performArchive($conversation, $thread, $user, $crm_archive, $conversation_data);
+            return;
+        }
+
+        $status = count($response) === 0
+            ? CrmArchiveAttempt::STATUS_FAILED_NO_CUSTOMER
+            : CrmArchiveAttempt::STATUS_FAILED_AMBIGUOUS_CUSTOMER;
+        CrmArchiveAttempt::record([
+            'conversation_id' => $conversation->id,
+            'thread_id' => $thread->id,
+            'user_id' => $user->id,
+            'status' => $status,
+            'reason' => $status === CrmArchiveAttempt::STATUS_FAILED_NO_CUSTOMER
+                ? 'Kein Ameise-Kunde fuer ' . $conversation->customer_email . ' gefunden.'
+                : 'Mehrere Ameise-Kunden (' . count($response) . ') fuer ' . $conversation->customer_email . ' gefunden.',
+        ]);
+    }
+
+    private function performArchive($conversation, $thread, $user, $crmArchive, array $conversation_data)
+    {
+        $scanOnly = $this->isScanOnly($conversation);
+        if ($scanOnly) {
+            $archiveResult = ['ok' => true, 'http_status' => null, 'body' => null, 'exception' => null, 'token_error' => false];
+        } else {
+            $archiveResult = $this->apiClient->archiveConversationDetailed($conversation_data);
+        }
+
+        if (!$archiveResult['ok']) {
+            $status = $archiveResult['token_error']
+                ? CrmArchiveAttempt::STATUS_FAILED_TOKEN
+                : CrmArchiveAttempt::STATUS_FAILED_API;
+            CrmArchiveAttempt::record([
+                'conversation_id' => $conversation->id,
+                'thread_id' => $thread->id,
+                'user_id' => $user->id,
+                'status' => $status,
+                'reason' => $archiveResult['exception']
+                    ?: ('HTTP ' . ($archiveResult['http_status'] ?? 'n/a')),
+                'http_status' => $archiveResult['http_status'],
+                'response_body' => $archiveResult['body'],
+            ]);
+            return;
+        }
+
+        $attachmentResult = $this->archiveConversationWithAttachments($thread, $conversation_data, $user);
+
+        if ($scanOnly && !$attachmentResult['archived_ok']) {
+            $lastFailure = $attachmentResult['last_failure'] ?? [];
+            CrmArchiveAttempt::record([
+                'conversation_id' => $conversation->id,
+                'thread_id' => $thread->id,
+                'user_id' => $user->id,
+                'status' => CrmArchiveAttempt::STATUS_FAILED_ATTACHMENT,
+                'reason' => '#scanonly: ' . ($lastFailure['reason'] ?? 'attachment failure') . ' (' . ($lastFailure['detail'] ?? '') . ')',
+                'http_status' => $lastFailure['http_status'] ?? null,
+                'response_body' => $lastFailure['body'] ?? null,
+                'attachments_total' => $attachmentResult['total'],
+                'attachments_failed' => $attachmentResult['failed'],
+            ]);
+            return;
+        }
+
+        CrmArchiveThread::create([
+            'crm_archive_id' => $crmArchive->id,
+            'thread_id' => $thread->id,
+            'conversation_id' => $conversation->id,
+        ]);
+
+        $status = $attachmentResult['archived_ok']
+            ? CrmArchiveAttempt::STATUS_SUCCESS
+            : CrmArchiveAttempt::STATUS_FAILED_ATTACHMENT;
+        $lastFailure = $attachmentResult['last_failure'] ?? [];
+        CrmArchiveAttempt::record([
+            'conversation_id' => $conversation->id,
+            'thread_id' => $thread->id,
+            'user_id' => $user->id,
+            'status' => $status,
+            'reason' => $status === CrmArchiveAttempt::STATUS_SUCCESS
+                ? null
+                : 'Nachricht archiviert, Anhang-Fehler: ' . ($lastFailure['reason'] ?? '') . ' (' . ($lastFailure['detail'] ?? '') . ')',
+            'http_status' => $status === CrmArchiveAttempt::STATUS_SUCCESS ? ($archiveResult['http_status'] ?? null) : ($lastFailure['http_status'] ?? null),
+            'response_body' => $status === CrmArchiveAttempt::STATUS_SUCCESS ? null : ($lastFailure['body'] ?? null),
+            'attachments_total' => $attachmentResult['total'],
+            'attachments_failed' => $attachmentResult['failed'],
+        ]);
     }
 }

--- a/Services/CrmApiClient.php
+++ b/Services/CrmApiClient.php
@@ -184,11 +184,32 @@ class CrmApiClient
 
     public function archiveConversation($data)
     {
+        return $this->archiveConversationDetailed($data)['ok'];
+    }
+
+    /**
+     * Sends the archive request and returns a structured result so callers
+     * can persist the failure reason (HTTP status, response body, exception).
+     *
+     * @return array{ok: bool, http_status: ?int, body: ?string, exception: ?string, token_error: bool}
+     */
+    public function archiveConversationDetailed($data)
+    {
+        $result = [
+            'ok' => false,
+            'http_status' => null,
+            'body' => null,
+            'exception' => null,
+            'token_error' => false,
+        ];
+
         try {
             $tokenError = $this->checkTokenError();
             if ($tokenError) {
                 $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Archive conversation skipped because token contains an error.');
-                return false;
+                $result['token_error'] = true;
+                $result['body'] = $this->sanitizeLogText(json_encode($tokenError) ?: '');
+                return $result;
             }
             $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Archive conversation request called.');
             $headers = [
@@ -204,28 +225,35 @@ class CrmApiClient
                 'headers' => $headers,
                 'body' => $data['body'],
             ]);
-            $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Response status: ' . $response->getStatusCode());
-            if ($response->getStatusCode() >= 200 && $response->getStatusCode() < 300) {
-                return true;
-            } elseif ($response->getStatusCode() === 401) {
+            $statusCode = $response->getStatusCode();
+            $result['http_status'] = $statusCode;
+            $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Response status: ' . $statusCode);
+            if ($statusCode >= 200 && $statusCode < 300) {
+                $result['ok'] = true;
+                return $result;
+            } elseif ($statusCode === 401) {
                 $this->tokenService->disconnectAmeise();
-            } else {
-                $errorResponse = json_decode($response->getBody(), true);
-                $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Request failed with status code: ' . $response->getStatusCode());
-                $this->ameiseLogStatus && \Helper::log(
-                    'conversation_archive',
-                    'Error response: ' . json_encode($this->sanitizeLogData($errorResponse))
-                );
             }
+            $rawBody = (string) $response->getBody();
+            $result['body'] = $this->sanitizeLogText($rawBody);
+            $errorResponse = json_decode($rawBody, true);
+            $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Request failed with status code: ' . $statusCode);
+            $this->ameiseLogStatus && \Helper::log(
+                'conversation_archive',
+                'Error response: ' . json_encode($this->sanitizeLogData($errorResponse))
+            );
         } catch (Exception $e) {
             $body = $e->hasResponse() ? (string) $e->getResponse()->getBody() : '';
-            $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Error body: ' . $this->sanitizeLogText($body));
+            $result['http_status'] = $e->hasResponse() ? $e->getResponse()->getStatusCode() : null;
+            $result['body'] = $this->sanitizeLogText($body);
+            $result['exception'] = $this->sanitizeLogText($e->getMessage());
+            $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Error body: ' . $result['body']);
             $this->ameiseLogStatus && \Helper::logException($e, 'conversation_archive');
             if ($e->getCode() === 401) {
                 $this->tokenService->disconnectAmeise();
             }
         }
-        return false;
+        return $result;
     }
 
     private function sanitizeLogData($data)


### PR DESCRIPTION
## Overview
This PR adds persistent tracking of failed conversation archiving attempts and provides tools to retry and manage them. Previously, archiving failures were only logged and difficult to diagnose or recover from. Now all attempts are recorded in a new `crm_archive_attempts` table with detailed failure reasons, HTTP status codes, and response bodies.

## Key Changes

### New Entity & Database
- **`CrmArchiveAttempt` model** with status constants for different failure types:
  - `failed_no_customer` / `failed_ambiguous_customer` – customer lookup issues
  - `failed_api` / `failed_token` – API/authentication errors
  - `failed_attachment` – partial attachment failures
  - `failed_exception` – uncaught exceptions
  - `success` / `pending` – successful or queued attempts
- **Migration** creates `crm_archive_attempts` table with indexes on conversation/thread/user/status for efficient querying

### Enhanced Archiving Logic
- **`ConversationArchiver`**:
  - Refactored `archiveConversationData()` to extract a new `performArchive()` method, reducing nesting and improving testability
  - Now records all failure scenarios (customer lookup, API errors, attachment failures) via `CrmArchiveAttempt::record()`
  - Returns structured result from `archiveConversationWithAttachments()` with total/failed counts and last failure details
  
- **`CrmApiClient`**:
  - New `archiveConversationDetailed()` method returns structured result object with HTTP status, response body, and exception details
  - Existing `archiveConversation()` now delegates to the detailed version for backward compatibility
  - Captures token errors and distinguishes them from other API failures

### Job & Queue Improvements
- **`ArchiveThreadsJob`**:
  - Added `$tries = 5` and `backoff()` array for exponential backoff (1m → 5m → 15m → 1h → 4h)
  - Wraps execution in try-catch to record exceptions via `CrmArchiveAttempt`
  - Implements `failed()` callback to log final failure after all retries exhausted

### CLI Commands
- **`ListFailedArchives`**: Lists unresolved failures with filtering by time range and status
  - Usage: `php artisan ameise:list-failed-archives --since=24h --status=failed_api`
- **`RetryFailedArchives`**: Manually re-queue failed attempts
  - Usage: `php artisan ameise:retry-failed-archives --conversation=123` or `--all`

### UI & Settings
- **Settings page** now displays a "Archivierungs-Fehler" section showing last 30 days of unresolved failures
- Buttons to retry individual attempts or dismiss all related attempts for a thread
- JavaScript handlers for async retry/dismiss actions

### Controller Endpoints
- `POST /ameise/archive_attempts/{id}/retry` – re-queue a failed attempt
- `POST /ameise/archive_attempts/{id}/dismiss` – mark all related attempts as resolved

## Benefits
- **Observability**: All archiving attempts are now permanently recorded with detailed failure reasons
- **Recoverability**: Failed attempts can be retried manually or automatically via CLI
- **Debugging**: HTTP status codes and response bodies are captured (sanitized) for troubleshooting
- **Resilience**: Queue job retries with exponential backoff handle transient failures automatically

## Test Plan
- Verify failed archiving attempts appear in Settings UI
- Test retry button queues job and updates attempt status
- Test dismiss button marks attempts as resolved
- Verify CLI commands list and retry failures correctly
- Confirm queue job retries on exception with proper backoff

https://claude.ai/code/session_01VU73s4KM5JZqVWQYPpK3cP