### PR TITLE
Skip system line items and unsent drafts in conversation archiver

### DIFF
--- a/Services/ConversationArchiver.php
+++ b/Services/ConversationArchiver.php
@@ -19,6 +19,20 @@ class ConversationArchiver
 
     public function shouldArchiveThread($conversation, $thread)
     {
+        // Never archive system line items (status changes, assignments, etc.).
+        // They carry no real content, so the CRM rejects them and the whole
+        // archive run would be reported as failed (dialog stays open).
+        if ($thread->type == Thread::TYPE_LINEITEM) {
+            return false;
+        }
+
+        // Skip threads that are not actually sent yet (e.g. auto-saved drafts).
+        // Archiving an unsent draft pushes incomplete content to the CRM and may
+        // fail, which would otherwise keep the archive dialog from closing.
+        if (isset($thread->state) && $thread->state != Thread::STATE_PUBLISHED) {
+            return false;
+        }
+
         if ($thread->type !== Thread::TYPE_NOTE) {
             return true;
         }


### PR DESCRIPTION
## Description

This PR adds two safety checks to the `shouldArchiveThread()` method in the conversation archiver to prevent failed archive operations:

1. **Skip system line items**: Never archive threads with `TYPE_LINEITEM` (status changes, assignments, etc.) as they carry no real content and the CRM rejects them, causing the entire archive run to fail.

2. **Skip unsent drafts**: Skip threads that haven't been published yet (e.g., auto-saved drafts) to prevent pushing incomplete content to the CRM, which could fail and prevent the archive dialog from closing.

These checks are performed before the existing `TYPE_NOTE` check to ensure problematic threads are filtered out early.

## Test Plan

The changes are defensive in nature and prevent edge cases that would cause archive failures. Existing tests should continue to pass, and the archive dialog should now close successfully even when conversations contain system line items or unsent drafts.

https://claude.ai/code/session_014aWbkVdZmsz3gBReN5Ahef