### PR TITLE
Handle missing conversation subjects with fallback text

### DIFF
--- a/Services/ConversationArchiver.php
+++ b/Services/ConversationArchiver.php
@@ -83,7 +83,9 @@ class ConversationArchiver
         return [
             'type' =>  ($conversation->type == Conversation::TYPE_EMAIL) ? 'email' : 'telefon',
             'x-dio-metadaten' => $x_dio_metadaten,
-            'subject' => $conversation->subject,
+            'subject' => trim((string) ($conversation->subject ?? '')) !== ''
+                ? $conversation->subject
+                : '(Kein Betreff)',
             'body' => $body,
             'Content-Type' => 'text/plain; charset=utf-8',
             'X-Dio-Datum' => Carbon::parse($thread->created_at)->setTimezone($userTimezone)->format('Y-m-d\TH:i:s'),

--- a/Services/CrmApiClient.php
+++ b/Services/CrmApiClient.php
@@ -191,8 +191,12 @@ class CrmApiClient
                 return false;
             }
             $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Archive conversation request called.');
+            $subject = isset($data['subject']) ? trim((string) $data['subject']) : '';
+            if ($subject === '') {
+                $subject = '(Kein Betreff)';
+            }
             $headers = [
-                'X-Dio-Betreff' =>  $data['subject'],
+                'X-Dio-Betreff' =>  $subject,
                 'x-dio-metadaten' =>  json_encode($data['x-dio-metadaten']),
                 'X-Dio-Typ' => $data['type'],
                 'Content-Type' => $data['Content-Type'] ??  'text/plain; charset="utf-8"',


### PR DESCRIPTION
## Description
This PR adds defensive handling for missing or empty conversation subjects when archiving conversations. Both the `ConversationArchiver` and `CrmApiClient` now validate and sanitize the subject field, providing a fallback text "(Kein Betreff)" (German for "No Subject") when the subject is empty or missing.

## Changes
- **ConversationArchiver**: Added validation to check if subject is empty after trimming, using fallback text if needed
- **CrmApiClient**: Added subject sanitization before setting the `X-Dio-Betreff` header, ensuring the header always contains a valid value

## Motivation
This prevents potential issues with empty or null subject values being sent to the CRM API, ensuring data consistency and improving the user experience by displaying a meaningful placeholder instead of blank subjects.

## Test Plan
- Verify that conversations with empty subjects are archived successfully with the fallback text
- Verify that conversations with valid subjects continue to work as before
- Confirm the `X-Dio-Betreff` header is properly set in both cases

https://claude.ai/code/session_01UAPeLynUWLkM2QjxAHLkMb