### PR TITLE
Auto-focus search field when opening user modal

### DIFF
--- a/Public/js/crm.js
+++ b/Public/js/crm.js
@@ -88,6 +88,11 @@ $(document).ready(function() {
         });
     });
 
+    $('#ameise-modal').on('shown.bs.modal', function () {
+        // Cursor direkt ins Suchfeld setzen, damit man sofort lostippen kann.
+        $('#crm_user').trigger('focus');
+    });
+
     $('#ameise-modal').on('hidden.bs.modal', function () {
         location.reload();
     });


### PR DESCRIPTION
## Description
Added auto-focus functionality to the `#crm_user` search field when the `#ameise-modal` is opened. This improves user experience by allowing users to immediately start typing in the search field without having to manually click on it first.

## Changes
- Added event listener for the `shown.bs.modal` event on the ameise modal
- Automatically triggers focus on the `#crm_user` input field when the modal is displayed

## Test Plan
Open the ameise modal and verify that the cursor is automatically placed in the search field, allowing immediate text input without manual focus.

https://claude.ai/code/session_01CbPBDTtBfSxNR41ZksdUbc