### PR TITLE
Handle long archive subjects

### DIFF
--- a/Services/ConversationArchiver.php
+++ b/Services/ConversationArchiver.php
@@ -10,6 +10,8 @@ use Modules\AmeiseModule\Entities\CrmArchiveThread;
 
 class ConversationArchiver
 {
+    private const MAX_SUBJECT_LENGTH = 128;
+
     private $apiClient;
 
     public function __construct(CrmApiClient $apiClient)
@@ -67,6 +69,13 @@ class ConversationArchiver
             $x_dio_metadaten[] = ['Value' => $key, 'Text' => $text];
         }
 
+        $subject = trim((string) ($conversation->subject ?? '')) !== ''
+            ? trim((string) $conversation->subject)
+            : '(Kein Betreff)';
+        if (mb_strlen($subject) > self::MAX_SUBJECT_LENGTH) {
+            $x_dio_metadaten[] = ['Value' => 'Vollständiger Betreff', 'Text' => $subject];
+        }
+
         $body = $thread->body ?? '';
         $body = html_entity_decode($body, ENT_QUOTES | ENT_HTML5);
         $body = str_replace(['<li>', '</li>'], ["\n- ", ''], $body);
@@ -83,9 +92,7 @@ class ConversationArchiver
         return [
             'type' =>  ($conversation->type == Conversation::TYPE_EMAIL) ? 'email' : 'telefon',
             'x-dio-metadaten' => $x_dio_metadaten,
-            'subject' => trim((string) ($conversation->subject ?? '')) !== ''
-                ? $conversation->subject
-                : '(Kein Betreff)',
+            'subject' => $subject,
             'body' => $body,
             'Content-Type' => 'text/plain; charset=utf-8',
             'X-Dio-Datum' => Carbon::parse($thread->created_at)->setTimezone($userTimezone)->format('Y-m-d\TH:i:s'),

--- a/Services/CrmApiClient.php
+++ b/Services/CrmApiClient.php
@@ -7,6 +7,8 @@ use GuzzleHttp\Exception\RequestException as Exception;
 
 class CrmApiClient
 {
+    private const MAX_SUBJECT_LENGTH = 128;
+
     private $base_url;
     private $tokenService;
     private $ameiseLogStatus;
@@ -196,7 +198,7 @@ class CrmApiClient
                 $subject = '(Kein Betreff)';
             }
             $headers = [
-                'X-Dio-Betreff' =>  $subject,
+                'X-Dio-Betreff' =>  $this->limitSubjectHeader($subject),
                 'x-dio-metadaten' =>  json_encode($data['x-dio-metadaten']),
                 'X-Dio-Typ' => $data['type'],
                 'Content-Type' => $data['Content-Type'] ??  'text/plain; charset="utf-8"',
@@ -230,6 +232,16 @@ class CrmApiClient
             }
         }
         return false;
+    }
+
+
+    private function limitSubjectHeader(string $subject): string
+    {
+        if (mb_strlen($subject) <= self::MAX_SUBJECT_LENGTH) {
+            return $subject;
+        }
+
+        return mb_substr($subject, 0, self::MAX_SUBJECT_LENGTH);
     }
 
     private function sanitizeLogData($data)


### PR DESCRIPTION
### Motivation
- Archiving requests were failing for emails with very long subjects because the `X-Dio-Betreff` header exceeded the observed 128-character boundary. 
- The change keeps the complete subject available in the CRM while avoiding header-length issues by providing the full subject as metadata when necessary.

### Description
- Introduce `MAX_SUBJECT_LENGTH = 128` in `Services\CrmApiClient` and `Services\ConversationArchiver` to centralize the length limit. 
- Add `limitSubjectHeader(string $subject)` to `Services\CrmApiClient` and use it when building the `X-Dio-Betreff` header so the header is truncated to 128 characters. 
- In `Services\ConversationArchiver::createConversationData` compute a normalized `subject` value and, if it exceeds 128 characters, add a metadata entry `Vollständiger Betreff` containing the full subject so the CRM still receives the complete text. 
- Ensure the archive payload `subject` field is populated consistently while the actual HTTP header is safely limited.

### Testing
- Ran `php -l Services/CrmApiClient.php` and the file passed syntax checks. 
- Ran `php -l Services/ConversationArchiver.php` and the file passed syntax checks. 
- Executed a PHP length smoke check verifying truncation behavior against the 128-character boundary and observed expected lengths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d605df9e483279b1c0b129bb92aa2)