### PR TITLE
Fixes zur automatischen Zuordnung: PHP-8.4-Deprecation und Ja/Nein-Einstellungen

### DIFF
--- a/Providers/AmeiseModuleServiceProvider.php
+++ b/Providers/AmeiseModuleServiceProvider.php
@@ -147,8 +147,13 @@ class AmeiseModuleServiceProvider extends ServiceProvider
             $settings['ameise_mode'] = config('ameisemodule.ameise_mode');
             $settings['ameise_client_id'] = config('ameisemodule.ameise_client_id');
             $settings['ameise_redirect_uri'] = route('crm.auth');
-            $settings['ameise_auto_assign'] = config('ameisemodule.ameise_auto_assign') ? '1' : '0';
-            $settings['ameise_auto_assign_contracts'] = config('ameisemodule.ameise_auto_assign_contracts') ? '1' : '0';
+            // Bewusst 'true'/'false' statt '1'/'0': FreeScout kann einen in der .env
+            // stehenden Wert '0' nicht mehr ersetzen (Helper::setEnvFileVar prüft
+            // `if ($old_value)`) und hängt stattdessen eine zweite Zeile an, von der
+            // phpdotenv die erste gewinnen lässt – die Einstellung ließe sich nie
+            // wieder einschalten.
+            $settings['ameise_auto_assign'] = config('ameisemodule.ameise_auto_assign') ? 'true' : 'false';
+            $settings['ameise_auto_assign_contracts'] = config('ameisemodule.ameise_auto_assign_contracts') ? 'true' : 'false';
             $settings['ameise_service_user_id'] = config('ameisemodule.ameise_service_user_id');
             $settings['ameise_auto_assign_mailboxes'] = config('ameisemodule.ameise_auto_assign_mailboxes');
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Unter *Einstellungen → Ameise*:
 
 4. Erst danach **Automatisch zuordnen** auf *Ja* stellen (`AMEISE_AUTO_ASSIGN=true`).
 
+Die beiden Ja/Nein-Einstellungen werden als `true`/`false` in die `.env` geschrieben. FreeScout
+kann einen dort stehenden Wert `0` nicht mehr ersetzen und hängt stattdessen eine zweite Zeile
+an, von der beim Einlesen die erste gewinnt. Springt eine Einstellung immer wieder auf *Nein*,
+in der `.env` nach doppelten `AMEISE_AUTO_ASSIGN`-Zeilen suchen und alle bis auf eine entfernen.
+
 Der Cron `ameise:auto-assign` läuft alle 10 Minuten und berücksichtigt Konversationen ohne
 jede Zuordnung, die nicht älter als `AMEISE_AUTO_ASSIGN_MAX_AGE_DAYS` (Standard 30) Tage sind.
 Folge-Nachrichten übernimmt wie bisher `ameise:archive-threads`.

--- a/Resources/views/settings.blade.php
+++ b/Resources/views/settings.blade.php
@@ -41,9 +41,14 @@
         <label for="" class="col-sm-2 control-label">{{ __('Automatisch zuordnen') }}</label>
 
         <div class="col-sm-6">
+            @php
+                // FILTER_VALIDATE_BOOLEAN akzeptiert 'true'/'false' ebenso wie ältere
+                // '1'/'0'-Werte, die vor diesem Fix in der .env gelandet sein können.
+                $ameiseAutoAssign = filter_var(old('settings[ameise_auto_assign]', $settings['ameise_auto_assign']), FILTER_VALIDATE_BOOLEAN);
+            @endphp
             <select class="form-control" name="settings[ameise_auto_assign]">
-                <option value="0" {{ old('settings[ameise_auto_assign]', $settings['ameise_auto_assign']) ? '' : 'selected' }}>{{ __('Nein') }}</option>
-                <option value="1" {{ old('settings[ameise_auto_assign]', $settings['ameise_auto_assign']) ? 'selected' : '' }}>{{ __('Ja') }}</option>
+                <option value="false" {{ $ameiseAutoAssign ? '' : 'selected' }}>{{ __('Nein') }}</option>
+                <option value="true" {{ $ameiseAutoAssign ? 'selected' : '' }}>{{ __('Ja') }}</option>
             </select>
             <p class="help-block">
                 {{ __('Konversationen werden nur bei eindeutigem Treffer (E-Mail-Adresse oder Kundennummer) automatisch archiviert. Ein falscher Archiveintrag kann in Ameise nicht gelöscht werden – zuvor mit "php artisan ameise:auto-assign --dry-run" prüfen.') }}
@@ -55,9 +60,12 @@
         <label for="" class="col-sm-2 control-label">{{ __('Verträge/Sparten zuordnen') }}</label>
 
         <div class="col-sm-6">
+            @php
+                $ameiseAutoAssignContracts = filter_var(old('settings[ameise_auto_assign_contracts]', $settings['ameise_auto_assign_contracts']), FILTER_VALIDATE_BOOLEAN);
+            @endphp
             <select class="form-control" name="settings[ameise_auto_assign_contracts]">
-                <option value="0" {{ old('settings[ameise_auto_assign_contracts]', $settings['ameise_auto_assign_contracts']) ? '' : 'selected' }}>{{ __('Nein') }}</option>
-                <option value="1" {{ old('settings[ameise_auto_assign_contracts]', $settings['ameise_auto_assign_contracts']) ? 'selected' : '' }}>{{ __('Ja') }}</option>
+                <option value="false" {{ $ameiseAutoAssignContracts ? '' : 'selected' }}>{{ __('Nein') }}</option>
+                <option value="true" {{ $ameiseAutoAssignContracts ? 'selected' : '' }}>{{ __('Ja') }}</option>
             </select>
             <p class="help-block">{{ __('Nur wenn die Versicherungsscheinnummer im Text steht oder der Kunde genau einen Vertrag hat.') }}</p>
         </div>

--- a/Services/ConversationArchiver.php
+++ b/Services/ConversationArchiver.php
@@ -16,7 +16,7 @@ class ConversationArchiver
     private $customerMatcher;
     private $contractMatcher;
 
-    public function __construct(CrmApiClient $apiClient, CustomerMatcher $customerMatcher = null, ContractMatcher $contractMatcher = null)
+    public function __construct(CrmApiClient $apiClient, ?CustomerMatcher $customerMatcher = null, ?ContractMatcher $contractMatcher = null)
     {
         $this->apiClient = $apiClient;
         $this->customerMatcher = $customerMatcher ?? new CustomerMatcher($apiClient);


### PR DESCRIPTION
Zwei Nachbesserungen zu #80, beide im Betrieb auf `support.risk007.de` aufgefallen.

## 1. PHP 8.4: implizit nullable Parameter

Bei jeder Instanziierung des `ConversationArchiver` lief eine Deprecation-Meldung ins Log:

> `ConversationArchiver::__construct(): Implicitly marking parameter $customerMatcher as nullable is deprecated`

Die beiden optionalen Matcher-Parameter sind jetzt explizit als `?CustomerMatcher` / `?ContractMatcher` typisiert. Funktional hat nichts gefehlt — der Archiver hat normal gearbeitet —, aber die Meldung wurde bei jeder Antwort und in jedem Cron-Lauf geschrieben und hätte das Log schnell zulaufen lassen. Das Modul wurde nach demselben Muster durchsucht; das war die einzige betroffene Stelle.

## 2. „Automatisch zuordnen" sprang immer wieder auf Nein

Die Einstellung ließ sich nicht dauerhaft auf *Ja* stellen. Ursache ist `Helper::setEnvFileVar()` im FreeScout-Kern:

```php
$old_value = substr($matches[0], strlen($key) + 1);   // "0"
if ($old_value) {                                     // "0" ist in PHP falsy
    // ersetzen …
} else {
    // … hängt stattdessen eine zweite Zeile ans .env-Ende an
}
```

Steht in der `.env` einmal `AMEISE_AUTO_ASSIGN=0`, kann dieser Wert nie wieder ersetzt werden. FreeScout hängt `AMEISE_AUTO_ASSIGN=1` zusätzlich unten an, und phpdotenv lässt bei doppelten Schlüsseln die erste Zeile gewinnen — also weiterhin die `0`.

Die beiden Ja/Nein-Einstellungen (`ameise_auto_assign`, `ameise_auto_assign_contracts`) speichern deshalb jetzt `true`/`false`. Als String ist `"false"` truthy und wird korrekt ersetzt; `env()` wandelt beide Strings ohnehin in echte Booleans um. Die Anzeige wertet den Wert über `FILTER_VALIDATE_BOOLEAN` aus, damit bereits geschriebene `1`/`0`-Werte weiterhin richtig dargestellt werden.

Nicht betroffen sind Service-Nutzer und Mailbox-Liste — dort muss weder eine `0` noch ein leerer Altwert überschrieben werden.

### Nach dem Deployment nötig

In bestehenden Installationen kann die `.env` bereits doppelte Zeilen enthalten:

```
grep -n "AMEISE_AUTO_ASSIGN" .env
```

Alle bis auf eine entfernen, dann `php artisan freescout:clear-cache`. Der Hinweis steht auch im README.

## Test

Nur statisch geprüft (`php -l`, Verhalten von `FILTER_VALIDATE_BOOLEAN` gegen `'true'`, `'false'`, `'1'`, `'0'`) — eine FreeScout-Instanz stand hier nicht zur Verfügung. Das Umschalten in den Einstellungen sollte auf der Installation gegengeprüft werden, nachdem die `.env` bereinigt ist.


---
_Generated by [Claude Code](https://claude.ai/code/session_015vrRWUP19a3Hn6xaUb2AAP)_