### PR TITLE
Replace hasResponse() with null check for exception handling

### DIFF
--- a/Services/CrmApiClient.php
+++ b/Services/CrmApiClient.php
@@ -70,7 +70,7 @@ class CrmApiClient
             if ($e->getCode() === 401) {
                 $this->tokenService->disconnectAmeise();
             }
-            if ($e->hasResponse()) {
+            if ($e->getResponse() !== null) {
                 $body = (string) $e->getResponse()->getBody();
                 $this->ameiseLogStatus && \Helper::log($logContext, 'Error body: ' . $this->sanitizeLogText($body));
             }
@@ -113,7 +113,7 @@ class CrmApiClient
             if ($e->getCode() === 401) {
                 $this->tokenService->disconnectAmeise();
             }
-            if ($e->hasResponse()) {
+            if ($e->getResponse() !== null) {
                 $body = (string) $e->getResponse()->getBody();
                 $this->ameiseLogStatus && \Helper::log($logContext, 'Error body: ' . $this->sanitizeLogText($body));
             }
@@ -224,7 +224,7 @@ class CrmApiClient
                 );
             }
         } catch (Exception $e) {
-            $body = $e->hasResponse() ? (string) $e->getResponse()->getBody() : '';
+            $body = $e->getResponse() !== null ? (string) $e->getResponse()->getBody() : '';
             $this->ameiseLogStatus && \Helper::log('conversation_archive', 'Error body: ' . $this->sanitizeLogText($body));
             $this->ameiseLogStatus && \Helper::logException($e, 'conversation_archive');
             if ($e->getCode() === 401) {

--- a/Services/TokenService.php
+++ b/Services/TokenService.php
@@ -206,7 +206,7 @@ class TokenService
 
     private function refreshRequestRequiresReauthentication(Exception $e): bool
     {
-        if (!$e->hasResponse()) {
+        if ($e->getResponse() === null) {
             return false;
         }
 


### PR DESCRIPTION
## Description

Replace calls to `hasResponse()` method with explicit null checks (`!== null`) when checking if an exception has a response object in the CRM API client and token service.

This change improves code clarity and consistency by using direct null comparison instead of relying on a helper method, making the intent more explicit and reducing potential issues if the `hasResponse()` method behavior changes or is deprecated.

## Changes

- **CrmApiClient.php**: Updated 3 instances in `apiGet()`, `apiPost()`, and `archiveConversation()` methods
- **TokenService.php**: Updated 1 instance in `refreshRequestRequiresReauthentication()` method

All changes maintain the same logical behavior while using more explicit null checks.

## Test Plan

N/A - This is a straightforward refactoring that maintains existing behavior. Existing tests should continue to pass.

https://claude.ai/code/session_01PHTcztwqkPLWK9tW2Z58TP