### PR TITLE
Absenderadressen von der Archivierung ausschließen

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -11,6 +11,10 @@ return [
     // Verbose logging can quickly grow the FreeScout activity_logs table.
     // Disable by default and allow opt-in via AMEISE_LOG_STATUS=true.
     'ameise_log_status' => env('AMEISE_LOG_STATUS', false),
+    // Absenderadressen, die nicht in die Ameise archiviert werden sollen.
+    // Mehrere Adressen per Komma, Semikolon oder Zeilenumbruch trennen.
+    // Die Einstellung im Ameise-Einstellungsmenü hat Vorrang vor diesem Wert.
+    'ameise_excluded_senders' => env('AMEISE_EXCLUDED_SENDERS', ''),
 
 ];
 

--- a/Console/Commands/ArchiveThreads.php
+++ b/Console/Commands/ArchiveThreads.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Modules\AmeiseModule\Entities\CrmArchive;
 use Modules\AmeiseModule\Entities\CrmArchiveThread;
 use Modules\AmeiseModule\Jobs\ArchiveThreadsJob;
+use Modules\AmeiseModule\Services\SenderExclusion;
 
 class ArchiveThreads extends Command
 {
@@ -50,7 +51,19 @@ class ArchiveThreads extends Command
             ->with(['conversation', 'attachments'])
             ->get();
 
+        $senderExclusion = new SenderExclusion();
+
         foreach ($threads as $thread) {
+            // Ausgeschlossene Absender gar nicht erst einreihen, sonst würde
+            // der Cron alle fünf Minuten vergeblich Jobs erzeugen.
+            if ($senderExclusion->isConfigured() && $thread->conversation) {
+                $excludedSender = $senderExclusion->getExcludedSender($thread->conversation, $thread);
+                if ($excludedSender !== null) {
+                    $senderExclusion->notify($thread->conversation, $excludedSender);
+                    continue;
+                }
+            }
+
             $archives = CrmArchive::where('conversation_id', $thread->conversation_id)
                 ->groupBy('archived_by')
                 ->pluck('archived_by')

--- a/Http/Controllers/AmeiseController.php
+++ b/Http/Controllers/AmeiseController.php
@@ -96,6 +96,7 @@ class AmeiseController extends Controller
                 // nur entstehen, wenn die Archivierung in der Ameise geklappt hat.
                 $allArchived = true;
                 $archivedThreadIds = [];
+                $excludedSenders = [];
                 foreach($conversation->threads as $thread) {
                     if ($crm_archive) {
                         $isArchiveThread = CrmArchiveThread::where('crm_archive_id', $crm_archive->id)->where('thread_id',$thread->id)->first();
@@ -104,6 +105,13 @@ class AmeiseController extends Controller
                         }
                     }
                     if (!$this->archiver->shouldArchiveThread($conversation, $thread)) {
+                        continue;
+                    }
+                    // Absender, die in den Einstellungen ausgeschlossen sind,
+                    // werden nicht archiviert.
+                    $excludedSender = $this->archiver->getExcludedSender($conversation, $thread);
+                    if ($excludedSender !== null) {
+                        $excludedSenders[$excludedSender] = $excludedSender;
                         continue;
                     }
                     $conversation_data = $this->archiver->createConversationData($conversation, $crm_user_id, $contracts, $divisions, $thread);
@@ -131,6 +139,24 @@ class AmeiseController extends Controller
                     ]);
                 }
 
+                // Es gab nur ausgeschlossene Absender: nichts archivieren, nichts
+                // zuordnen - der Benutzer bekommt eine Mitteilung.
+                if (empty($archivedThreadIds) && !empty($excludedSenders)) {
+                    \Helper::log(
+                        'conversation_archive',
+                        'Archivierung übersprungen, da die Absenderadresse ausgeschlossen ist ('
+                            . implode(', ', $excludedSenders) . ', conversation_id: ' . $conversation->id . ').'
+                    );
+
+                    return response()->json([
+                        'status' => false,
+                        'notice' => __(
+                            'Die Archivierung wurde übersprungen: Die Absenderadresse :sender ist in den Ameise-Einstellungen von der Archivierung ausgeschlossen.',
+                            ['sender' => implode(', ', $excludedSenders)]
+                        ),
+                    ]);
+                }
+
                 if(!$crm_archive) {
                     $crm_archive = new CrmArchive();
                     $crm_archive->crm_user_id = $crm_user_id;
@@ -150,6 +176,13 @@ class AmeiseController extends Controller
                 if (!$allArchived) {
                     // Teilerfolg: die bereits archivierten Threads bleiben zugeordnet.
                     $response['message'] = __('Nicht alle Nachrichten konnten in der Ameise archiviert werden.');
+                }
+                if (!empty($excludedSenders)) {
+                    // Einzelne Nachrichten wurden wegen des Absenders übersprungen.
+                    $response['notice'] = __(
+                        'Nicht alle Nachrichten wurden archiviert: Die Absenderadresse :sender ist in den Ameise-Einstellungen von der Archivierung ausgeschlossen.',
+                        ['sender' => implode(', ', $excludedSenders)]
+                    );
                 }
 
                 return response()->json($response);

--- a/Providers/AmeiseModuleServiceProvider.php
+++ b/Providers/AmeiseModuleServiceProvider.php
@@ -139,7 +139,7 @@ class AmeiseModuleServiceProvider extends ServiceProvider
     {
         // Add item to settings sections.
         Eventy::addFilter('settings.sections', function ($sections) {
-            $sections['ameise'] = [ 'title' => __('Ameise'), 'icon' => 'headphones', 'order' => 200 ];
+            $sections['ameise'] = [ 'title' => __('Ameise'), 'icon' => 'briefcase', 'order' => 200 ];
 
             return $sections;
         }, 15);

--- a/Providers/AmeiseModuleServiceProvider.php
+++ b/Providers/AmeiseModuleServiceProvider.php
@@ -105,6 +105,16 @@ class AmeiseModuleServiceProvider extends ServiceProvider
             return;
         }
 
+        $archiver = $this->createArchiver($user->id);
+
+        // Ausgeschlossene Absender werden weder archiviert noch zugeordnet.
+        $excludedSender = $archiver->getExcludedSender($forwarded_conversation, $forwarded_thread);
+        if ($excludedSender !== null) {
+            $archiver->notifyExcludedSender($forwarded_conversation, $excludedSender);
+
+            return;
+        }
+
         $existingArchive = \Modules\AmeiseModule\Entities\CrmArchive::where('conversation_id', $conversation->id)
             ->where('archived_by', $user->id)
             ->first();
@@ -119,7 +129,7 @@ class AmeiseModuleServiceProvider extends ServiceProvider
             ]);
         }
 
-        $this->createArchiver($user->id)->archiveConversationData($forwarded_conversation, $forwarded_thread, $user);
+        $archiver->archiveConversationData($forwarded_conversation, $forwarded_thread, $user);
     }
 
     /**
@@ -144,6 +154,9 @@ class AmeiseModuleServiceProvider extends ServiceProvider
             $settings['ameise_mode'] = config('ameisemodule.ameise_mode');
             $settings['ameise_client_id'] = config('ameisemodule.ameise_client_id');
             $settings['ameise_redirect_uri'] = route('crm.auth');
+            // Wird als Option in der Datenbank gespeichert (mehrzeilig, deshalb
+            // kein .env-Eintrag).
+            $settings['ameise_excluded_senders'] = \Modules\AmeiseModule\Services\SenderExclusion::getRawSetting();
 
             return $settings;
         }, 20, 2);

--- a/Providers/AmeiseModuleServiceProvider.php
+++ b/Providers/AmeiseModuleServiceProvider.php
@@ -53,6 +53,16 @@ class AmeiseModuleServiceProvider extends ServiceProvider
             echo View::make('ameise::partials/conversation_button', ['url' => $url])->render();
         }, 10, 2);
 
+        // Stylesheet für das Ameise-Icon in der Einstellungs-Sidebar. Nur auf der
+        // Einstellungsseite nötig, deshalb nicht global einbinden.
+        Eventy::addAction('layout.head', function () {
+            if (!\Helper::isRoute('settings')) {
+                return;
+            }
+            echo '<link href="' . asset(\Module::getPublicPath(AMEISE_MODULE) . '/css/settings.css')
+                . '" rel="stylesheet" type="text/css">';
+        });
+
         Eventy::addAction('layout.body_bottom', function () {
             echo View::make('ameise::partials/crm_modal')->render();
         }, 10, 2);
@@ -139,7 +149,10 @@ class AmeiseModuleServiceProvider extends ServiceProvider
     {
         // Add item to settings sections.
         Eventy::addFilter('settings.sections', function ($sections) {
-            $sections['ameise'] = [ 'title' => __('Ameise'), 'icon' => 'briefcase', 'order' => 200 ];
+            // "ameise" ist kein Bootstrap-Glyphicon, sondern ein eigener Modifier:
+            // FreeScout rendert daraus <i class="glyphicon glyphicon-ameise">, das
+            // Modul zeichnet darin per settings.css das Ameisen-Icon.
+            $sections['ameise'] = [ 'title' => __('Ameise'), 'icon' => 'ameise', 'order' => 200 ];
 
             return $sections;
         }, 15);

--- a/Public/css/settings.css
+++ b/Public/css/settings.css
@@ -1,0 +1,38 @@
+/*
+ * Icon der Ameise-Sektion in der Einstellungs-Sidebar.
+ *
+ * FreeScout rendert das Sektions-Icon fest als <i class="glyphicon glyphicon-{icon}">.
+ * Statt eines Bootstrap-Glyphicons registriert das Modul deshalb den eigenen
+ * Modifier "glyphicon-ameise" (siehe AmeiseModuleServiceProvider) und zeichnet
+ * darin das Ameisen-Icon, das auch zum Archivieren angeklickt wird.
+ */
+.glyphicon-ameise:before {
+    content: "";
+    display: block;
+    width: 16px;
+    height: 16px;
+    background-image: url('../images/ameise_icon_bold_green.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+/*
+ * Wo Masken unterstützt werden, übernimmt die Ameise die Farbe der übrigen
+ * Sidebar-Icons (grau, blau wenn aktiv) und fügt sich damit ins Menü ein.
+ * Ohne Maskenunterstützung bleibt es beim grünen Icon oben.
+ */
+@supports ((-webkit-mask-image: url('')) or (mask-image: url(''))) {
+    .glyphicon-ameise:before {
+        background-image: none;
+        background-color: currentColor;
+        -webkit-mask-image: url('../images/ameise_icon_bold.svg');
+        mask-image: url('../images/ameise_icon_bold.svg');
+        -webkit-mask-size: contain;
+        mask-size: contain;
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+        mask-position: center;
+    }
+}

--- a/Public/js/crm.js
+++ b/Public/js/crm.js
@@ -9,6 +9,7 @@ $(document).ready(function() {
         const archive_btn = $('#archive_btn');
 
         showArchiveError('');
+        showArchiveNotice('');
         setArchiveRunning(false);
 
         const input = document.getElementById('crm_user');
@@ -212,6 +213,7 @@ $(document).ready(function() {
         processSelectedData($('#division-tag-dropdown').select2('data'), 'divisions_data');
 
         showArchiveError('');
+        showArchiveNotice('');
         setArchiveRunning(true);
 
         $.ajax({
@@ -219,7 +221,7 @@ $(document).ready(function() {
             type: 'POST',
             data: combinedData,
             success: function(response) {
-                if (response.status) {
+                if (response.status && !response.notice) {
                     // Animation weiterlaufen lassen, bis der Reload greift.
                     location.reload();
                     return;
@@ -227,6 +229,15 @@ $(document).ready(function() {
                 setArchiveRunning(false);
                 if(response.error == 'Redirect'){
                     window.open(response.url, '_blank');
+                } else if (response.notice) {
+                    // Absender ist von der Archivierung ausgeschlossen: Mitteilung
+                    // anzeigen und den Dialog offen lassen, damit sie gelesen wird.
+                    // Der Reload folgt beim Schließen des Dialogs.
+                    showArchiveNotice(response.notice);
+                    if (response.message) {
+                        showArchiveError(response.message);
+                    }
+                    $('#archive_btn').hide();
                 } else {
                     // Archivierung fehlgeschlagen: die Zuordnung wurde serverseitig
                     // nicht gespeichert, deshalb hier auch nicht neu laden.
@@ -239,6 +250,17 @@ $(document).ready(function() {
             }
         });
     });
+
+    // Mitteilung, wenn Nachrichten wegen eines ausgeschlossenen Absenders
+    // nicht archiviert wurden.
+    function showArchiveNotice(message) {
+        const noticeBox = $('#ameise-archive-notice');
+        if (!message) {
+            noticeBox.hide().text('');
+            return;
+        }
+        noticeBox.text(message).show();
+    }
 
     function showArchiveError(message) {
         const errorBox = $('#ameise-archive-error');

--- a/README.md
+++ b/README.md
@@ -26,6 +26,28 @@ ein übermäßiges Wachstum der `activity_logs`-Tabelle. Bei Bedarf können Sie 
 ## Attachment Handling
 Image attachments are automatically converted to PDF before being archived.
 
+## Absender von der Archivierung ausschließen
+Unter *Einstellungen → Ameise → Ausgeschlossene Absender* können Absenderadressen
+hinterlegt werden, deren E-Mails nicht in der Ameise archiviert werden
+(eine Adresse pro Zeile, alternativ per Komma oder Semikolon getrennt).
+
+Unterstützte Schreibweisen:
+
+* `newsletter@example.com` – genau diese Adresse
+* `*@no-reply.example.com` – Platzhalter (`*` und `?`) an beliebiger Stelle
+* `@example.com` bzw. `example.com` – die komplette Domain
+
+Geprüft werden der Absender der Nachricht und der Kunde der Konversation, damit
+auch eigene Antworten an eine ausgeschlossene Adresse nicht archiviert werden.
+
+Wird eine solche E-Mail übersprungen, erhält der Benutzer eine Mitteilung:
+beim manuellen Archivieren direkt im Archivierungsdialog, beim Antworten oder
+Weiterleiten als Hinweis in der Oberfläche. Im Cron-Lauf wird nur ein
+Log-Eintrag geschrieben (siehe `AMEISE_LOG_STATUS`).
+
+Als Vorbelegung kann die Umgebungsvariable `AMEISE_EXCLUDED_SENDERS` gesetzt
+werden; die Einstellung im Einstellungsmenü hat Vorrang.
+
 ## Scan Only Modus
 Wenn der Betreff einer E-Mail `#scanonly` enthält, werden nur die Anhänge archiviert –
 die E-Mail selbst wird nicht an Ameise übertragen. Die Erkennung ist case-insensitive

--- a/Resources/views/partials/crm_modal.blade.php
+++ b/Resources/views/partials/crm_modal.blade.php
@@ -7,6 +7,7 @@
           </div>
           <div class="modal-body">
 <div id="ameise-archive-error" class="alert alert-danger" style="display: none;"></div>
+<div id="ameise-archive-notice" class="alert alert-warning" style="display: none;"></div>
 <form id="crm_user_form">
   <div class="form_user_crm">
       <span>{{__('Search')}}</span>

--- a/Resources/views/settings.blade.php
+++ b/Resources/views/settings.blade.php
@@ -34,6 +34,18 @@
         </div>
     </div>
 
+    <div class="form-group">
+        <label for="ameise_excluded_senders" class="col-sm-2 control-label">{{ __('Ausgeschlossene Absender') }}</label>
+
+        <div class="col-sm-6">
+            <textarea class="form-control" id="ameise_excluded_senders" name="settings[ameise_excluded_senders]" rows="5" placeholder="newsletter@example.com&#10;*@no-reply.example.com">{{ old('settings.ameise_excluded_senders', $settings['ameise_excluded_senders']) }}</textarea>
+            <p class="help-block">
+                {{ __('Eine Absenderadresse pro Zeile. E-Mails dieser Absender werden nicht in der Ameise archiviert; der Benutzer erhält stattdessen eine Mitteilung.') }}
+                {{ __('Platzhalter sind erlaubt (z. B. *@example.com). Ein Eintrag ohne lokalen Teil (z. B. @example.com) schließt die komplette Domain aus.') }}
+            </p>
+        </div>
+    </div>
+
     <div class="form-group margin-top margin-bottom">
         <div class="col-sm-6 col-sm-offset-2">
             <button type="submit" class="btn btn-primary">

--- a/Services/ConversationArchiver.php
+++ b/Services/ConversationArchiver.php
@@ -14,9 +14,29 @@ class ConversationArchiver
 
     private $apiClient;
 
-    public function __construct(CrmApiClient $apiClient)
+    private $senderExclusion;
+
+    public function __construct(CrmApiClient $apiClient, SenderExclusion $senderExclusion = null)
     {
         $this->apiClient = $apiClient;
+        $this->senderExclusion = $senderExclusion ?: new SenderExclusion();
+    }
+
+    /**
+     * Liefert die in den Einstellungen ausgeschlossene Absenderadresse der
+     * Konversation bzw. des Threads oder null.
+     */
+    public function getExcludedSender($conversation, $thread = null)
+    {
+        return $this->senderExclusion->getExcludedSender($conversation, $thread);
+    }
+
+    /**
+     * Benachrichtigt den Benutzer über eine wegen des Absenders übersprungene E-Mail.
+     */
+    public function notifyExcludedSender($conversation, $sender)
+    {
+        $this->senderExclusion->notify($conversation, $sender);
     }
 
     public function shouldArchiveThread($conversation, $thread)
@@ -161,6 +181,15 @@ class ConversationArchiver
         $thread =  $thread ?? $conversation->getLastThread();
         $user = $user ?? auth()->user();
         if ($this->shouldArchiveThread($conversation, $thread)) {
+            // Absender, die in den Einstellungen ausgeschlossen sind, werden
+            // nicht archiviert - der Benutzer bekommt eine Mitteilung.
+            $excludedSender = $this->getExcludedSender($conversation, $thread);
+            if ($excludedSender !== null) {
+                $this->notifyExcludedSender($conversation, $excludedSender);
+
+                return;
+            }
+
             $crmArchives = CrmArchive::where('conversation_id', $conversation->id)->get();
             if (count($crmArchives) > 0) {
                 foreach ($crmArchives as $crmArchive) {

--- a/Services/SenderExclusion.php
+++ b/Services/SenderExclusion.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Modules\AmeiseModule\Services;
+
+/**
+ * Absenderadressen, die in den Ameise-Einstellungen von der Archivierung
+ * ausgeschlossen wurden.
+ *
+ * Die Liste wird im Einstellungsmenü gepflegt (eine Adresse pro Zeile) und in
+ * der FreeScout-Options-Tabelle gespeichert. Als Vorbelegung dient die
+ * Umgebungsvariable AMEISE_EXCLUDED_SENDERS.
+ */
+class SenderExclusion
+{
+    const OPTION_NAME = 'ameise_excluded_senders';
+
+    /**
+     * Gecachte, normalisierte Muster.
+     *
+     * @var array|null
+     */
+    private $patterns = null;
+
+    /**
+     * Rohwert der Einstellung, wie er im Einstellungsformular angezeigt wird.
+     *
+     * @return string
+     */
+    public static function getRawSetting()
+    {
+        $raw = null;
+
+        try {
+            if (class_exists('\App\Option')) {
+                $raw = \App\Option::get(self::OPTION_NAME, config('ameisemodule.ameise_excluded_senders'));
+            }
+        } catch (\Exception $e) {
+            // Ohne Datenbank (z. B. während der Installation) greift die Config.
+            $raw = null;
+        }
+
+        if ($raw === null || $raw === false) {
+            $raw = config('ameisemodule.ameise_excluded_senders');
+        }
+
+        if (is_array($raw)) {
+            $raw = implode("\n", $raw);
+        }
+
+        return (string) $raw;
+    }
+
+    /**
+     * Normalisierte Muster der ausgeschlossenen Absender.
+     *
+     * @return array
+     */
+    public function getPatterns()
+    {
+        if (is_array($this->patterns)) {
+            return $this->patterns;
+        }
+
+        $patterns = preg_split('/[\r\n,;]+/', self::getRawSetting());
+        $patterns = array_map(function ($pattern) {
+            return mb_strtolower(trim((string) $pattern));
+        }, is_array($patterns) ? $patterns : []);
+
+        $this->patterns = array_values(array_unique(array_filter($patterns, function ($pattern) {
+            return $pattern !== '';
+        })));
+
+        return $this->patterns;
+    }
+
+    /**
+     * Ist überhaupt ein Absender ausgeschlossen?
+     *
+     * @return bool
+     */
+    public function isConfigured()
+    {
+        return !empty($this->getPatterns());
+    }
+
+    /**
+     * Liefert die ausgeschlossene Adresse der Konversation bzw. des Threads
+     * oder null, wenn nichts ausgeschlossen ist.
+     *
+     * @param \App\Conversation $conversation
+     * @param \App\Thread|null  $thread
+     *
+     * @return string|null
+     */
+    public function getExcludedSender($conversation, $thread = null)
+    {
+        $patterns = $this->getPatterns();
+        if (empty($patterns)) {
+            return null;
+        }
+
+        foreach ($this->collectAddresses($conversation, $thread) as $address) {
+            foreach ($patterns as $pattern) {
+                if ($this->matches($address, $pattern)) {
+                    return $address;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Mitteilungstext für eine übersprungene E-Mail.
+     *
+     * @param string $sender
+     *
+     * @return string
+     */
+    public function getMessage($sender)
+    {
+        return __(
+            'Die E-Mail von :sender wurde nicht in der Ameise archiviert, da diese Absenderadresse in den Ameise-Einstellungen von der Archivierung ausgeschlossen ist.',
+            ['sender' => $sender]
+        );
+    }
+
+    /**
+     * Benachrichtigt den Benutzer über eine übersprungene E-Mail.
+     *
+     * Im Web-Request erscheint eine Meldung im Oberflächen-Overlay, im Cron
+     * bzw. Queue-Worker bleibt nur der (optionale) Log-Eintrag.
+     *
+     * @param \App\Conversation $conversation
+     * @param string            $sender
+     */
+    public function notify($conversation, $sender)
+    {
+        $message = $this->getMessage($sender);
+        $context = ' (conversation_id: ' . ($conversation->id ?? '') . ')';
+
+        if (app()->runningInConsole()) {
+            config('ameisemodule.ameise_log_status') && \Helper::log('Ameise Cron Log', $message . $context);
+
+            return;
+        }
+
+        \Helper::log('conversation_archive', $message . $context);
+
+        try {
+            \Session::flash('flash_warning_floating', htmlspecialchars($message, ENT_QUOTES, 'UTF-8'));
+        } catch (\Exception $e) {
+            // Ohne Session genügt der Log-Eintrag.
+        }
+    }
+
+    /**
+     * Alle Adressen, die als Absender der Konversation in Frage kommen.
+     *
+     * Neben dem Absender des Threads zählt auch der Kunde der Konversation:
+     * sonst würden eigene Antworten an eine ausgeschlossene Adresse trotzdem
+     * archiviert.
+     *
+     * @return array
+     */
+    private function collectAddresses($conversation, $thread = null)
+    {
+        $addresses = [];
+
+        if ($thread && !empty($thread->from)) {
+            $addresses[] = $thread->from;
+        }
+
+        if (!empty($conversation->customer_email)) {
+            $addresses[] = $conversation->customer_email;
+        }
+
+        $result = [];
+        foreach ($addresses as $address) {
+            $address = $this->normalizeAddress($address);
+            if ($address !== '' && !in_array($address, $result, true)) {
+                $result[] = $address;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * "Name <mail@example.com>" -> "mail@example.com".
+     *
+     * @return string
+     */
+    private function normalizeAddress($address)
+    {
+        $address = trim((string) $address);
+        if ($address === '') {
+            return '';
+        }
+
+        if (preg_match('/<([^<>]+)>/', $address, $matches)) {
+            $address = trim($matches[1]);
+        }
+
+        return mb_strtolower($address);
+    }
+
+    /**
+     * Vergleicht eine Adresse mit einem Muster aus den Einstellungen.
+     *
+     * Unterstützt werden vollständige Adressen, Platzhalter (* und ?) sowie
+     * reine Domains ("@example.com" bzw. "example.com").
+     *
+     * @return bool
+     */
+    private function matches($address, $pattern)
+    {
+        if ($address === '' || $pattern === '') {
+            return false;
+        }
+
+        if ($address === $pattern) {
+            return true;
+        }
+
+        if (strpos($pattern, '*') !== false || strpos($pattern, '?') !== false) {
+            $regex = '/^' . str_replace(['\*', '\?'], ['.*', '.'], preg_quote($pattern, '/')) . '$/u';
+
+            return (bool) preg_match($regex, $address);
+        }
+
+        // Eintrag ohne lokalen Teil schließt die komplette Domain aus.
+        $atPosition = strpos($pattern, '@');
+        if ($atPosition === false || $atPosition === 0) {
+            $domain = '@' . ltrim($pattern, '@');
+
+            return substr($address, -strlen($domain)) === $domain;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Im Einstellungsmenü (Einstellungen -> Ameise) lassen sich jetzt Absender-
adressen hinterlegen, deren E-Mails nicht in der Ameise archiviert werden.
Eintragbar sind vollständige Adressen, Platzhalter (*@example.com) sowie
reine Domains (@example.com bzw. example.com); mehrere Einträge werden per
Zeilenumbruch, Komma oder Semikolon getrennt. Die Liste wird als Option in
der Datenbank gespeichert und kann per AMEISE_EXCLUDED_SENDERS vorbelegt
werden.

Geprüft werden der Absender des Threads und der Kunde der Konversation,
damit auch eigene Antworten an eine ausgeschlossene Adresse übersprungen
werden.

Der Benutzer bekommt eine Mitteilung, wenn eine solche E-Mail nicht
archiviert wird:
- beim manuellen Archivieren als Hinweis im Archivierungsdialog (komplett
  übersprungen wie auch nur teilweise), ohne dass eine Zuordnung entsteht,
- beim Antworten/Weiterleiten als Hinweis-Overlay in der Oberfläche,
- im Cron- bzw. Queue-Lauf als Log-Eintrag (über AMEISE_LOG_STATUS).

Der Cron-Befehl filtert ausgeschlossene Absender vorab heraus, damit nicht
alle fünf Minuten vergebliche Jobs erzeugt werden.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TRPvifniwcuq4PV7DXn6Fg