### PR TITLE
Add nullable type hint to SenderExclusion parameter

### DIFF
--- a/Services/ConversationArchiver.php
+++ b/Services/ConversationArchiver.php
@@ -16,7 +16,7 @@ class ConversationArchiver
 
     private $senderExclusion;
 
-    public function __construct(CrmApiClient $apiClient, SenderExclusion $senderExclusion = null)
+    public function __construct(CrmApiClient $apiClient, ?SenderExclusion $senderExclusion = null)
     {
         $this->apiClient = $apiClient;
         $this->senderExclusion = $senderExclusion ?: new SenderExclusion();


### PR DESCRIPTION
## Description
Updated the type hint for the `$senderExclusion` parameter in `ConversationArchiver::__construct()` to use PHP 7.1+ nullable type syntax (`?SenderExclusion`) instead of relying on the default `null` value alone.

This change improves code clarity by explicitly declaring that the parameter accepts `null` as a valid value, making the intent more obvious to developers and static analysis tools.

## Changes
- Modified `ConversationArchiver` constructor parameter type hint from `SenderExclusion $senderExclusion = null` to `?SenderExclusion $senderExclusion = null`

## Test Plan
No testing needed - this is a type hint clarification with no behavioral changes. The constructor logic remains identical.

https://claude.ai/code/session_01TyZhbiJLivdixL6rEz7juU